### PR TITLE
Fix/verify legacy rule

### DIFF
--- a/backend/src/services/discord.service.ts
+++ b/backend/src/services/discord.service.ts
@@ -123,7 +123,7 @@ export class DiscordService {
         const minItems = interaction.options.getInteger('min_items') || null;
         
         // Defer the reply early to prevent timeout
-        await interaction.deferReply({ ephemeral: true });
+        await interaction.deferReply({ flags: MessageFlags.Ephemeral });
         
         const rule = await this.dbSvc.addRoleMapping(
           interaction.guild.id,
@@ -212,7 +212,7 @@ export class DiscordService {
         const ruleId = interaction.options.getInteger('rule_id');
         
         // Defer the reply early to prevent timeout
-        await interaction.deferReply({ ephemeral: true });
+        await interaction.deferReply({ flags: MessageFlags.Ephemeral });
         
         try {
           await this.dbSvc.deleteRoleMapping(String(ruleId), interaction.guild.id);
@@ -233,7 +233,7 @@ export class DiscordService {
         // No channel option: list all rules for the server
         
         // Defer the reply early to prevent timeout
-        await interaction.deferReply({ ephemeral: true });
+        await interaction.deferReply({ flags: MessageFlags.Ephemeral });
         
         const rules = await this.dbSvc.getAllRulesWithLegacy(
           interaction.guild.id
@@ -264,7 +264,7 @@ export class DiscordService {
         // Remove all legacy roles for this guild using DbService
         
         // Defer the reply early to prevent timeout
-        await interaction.deferReply({ ephemeral: true });
+        await interaction.deferReply({ flags: MessageFlags.Ephemeral });
         
         const legacyRolesResult = await this.dbSvc.getLegacyRoles(interaction.guild.id);
         const legacyRoles = legacyRolesResult.data;
@@ -292,7 +292,7 @@ export class DiscordService {
         }
         
         // Defer the reply early to prevent timeout
-        await interaction.deferReply({ ephemeral: true });
+        await interaction.deferReply({ flags: MessageFlags.Ephemeral });
         
         // Get legacy roles
         const legacyRolesResult = await this.dbSvc.getLegacyRoles(interaction.guild.id);
@@ -378,7 +378,7 @@ export class DiscordService {
   async requestVerification(interaction: ButtonInteraction<CacheType>): Promise<void> {
     try {
       // Defer the reply early to prevent timeout
-      await interaction.deferReply({ ephemeral: true });
+      await interaction.deferReply({ flags: MessageFlags.Ephemeral });
       
       const guild = interaction.guild;
       if (!guild) throw new Error('Guild not found');


### PR DESCRIPTION
This pull request makes updates to improve error handling and verification logic in the `DiscordService` and `VerifyService` classes. The main changes include replacing the `ephemeral` property with `flags: MessageFlags.Ephemeral` for deferred replies and adding checks to ensure users own assets before proceeding with verification.

### Updates to `DiscordService`:

* Replaced the `ephemeral: true` property with `flags: MessageFlags.Ephemeral` in deferred replies across multiple methods to align with updated API standards. (`[[1]](diffhunk://#diff-f4f7eaa546e192917a87a7fe97c6c24e6abd71d7f1a248374cb8050c0952eb71L126-R126)`, `[[2]](diffhunk://#diff-f4f7eaa546e192917a87a7fe97c6c24e6abd71d7f1a248374cb8050c0952eb71L215-R215)`, `[[3]](diffhunk://#diff-f4f7eaa546e192917a87a7fe97c6c24e6abd71d7f1a248374cb8050c0952eb71L236-R236)`, `[[4]](diffhunk://#diff-f4f7eaa546e192917a87a7fe97c6c24e6abd71d7f1a248374cb8050c0952eb71L267-R267)`, `[[5]](diffhunk://#diff-f4f7eaa546e192917a87a7fe97c6c24e6abd71d7f1a248374cb8050c0952eb71L295-R295)`, `[[6]](diffhunk://#diff-f4f7eaa546e192917a87a7fe97c6c24e6abd71d7f1a248374cb8050c0952eb71L381-R381)`)

### Updates to `VerifyService`:

* Added asset ownership checks before proceeding with message-based verification. If the user does not own any assets, an error is thrown and logged. (`[backend/src/services/verify.service.tsR43-R51](diffhunk://#diff-ed7d5c499629907923dbd53d567dbcbc43e6d89b25bf26678c802e8d0228c265R43-R51)`)
* Implemented asset ownership validation in the legacy verification path, ensuring users own assets before roles are assigned. (`[backend/src/services/verify.service.tsR74-R82](diffhunk://#diff-ed7d5c499629907923dbd53d567dbcbc43e6d89b25bf26678c802e8d0228c265R74-R82)`)
* Added asset ownership validation in the new multi-rule verification path, logging and throwing errors if no assets are found. (`[backend/src/services/verify.service.tsR102-R109](diffhunk://#diff-ed7d5c499629907923dbd53d567dbcbc43e6d89b25bf26678c802e8d0228c265R102-R109)`)