### PR TITLE
Fix/service size issue

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -6,6 +6,9 @@ import { AppController } from '@/app.controller';
 import { AppService } from '@/app.service';
 
 import { DiscordService } from '@/services/discord.service';
+import { DiscordMessageService } from '@/services/discord-message.service';
+import { DiscordVerificationService } from '@/services/discord-verification.service';
+import { DiscordCommandsService } from '@/services/discord-commands.service';
 import { NonceService } from '@/services/nonce.service';
 import { WalletService } from '@/services/wallet.service';
 import { DbService } from '@/services/db.service';
@@ -21,6 +24,9 @@ import { VerifyService } from './services/verify.service';
   providers: [
     AppService,
     DiscordService,
+    DiscordMessageService,
+    DiscordVerificationService,
+    DiscordCommandsService,
     NonceService,
     WalletService,
     DbService,

--- a/backend/src/services/discord-commands.service.ts
+++ b/backend/src/services/discord-commands.service.ts
@@ -1,0 +1,277 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ChatInputCommandInteraction, EmbedBuilder, MessageFlags, ChannelType, GuildTextBasedChannel } from 'discord.js';
+import { DbService } from './db.service';
+import { DiscordMessageService } from './discord-message.service';
+
+@Injectable()
+export class DiscordCommandsService {
+  /**
+   * Initialize the service with the Discord client.
+   * This service doesn't directly use the client but maintains consistency.
+   */
+  initialize(client: any): void {
+    // No client needed for this service
+  }
+
+  constructor(
+    private readonly dbSvc: DbService,
+    private readonly messageSvc: DiscordMessageService
+  ) {}
+
+  async handleAddRule(interaction: ChatInputCommandInteraction): Promise<void> {
+    // Check if there are legacy roles that need to be migrated
+    const legacyRolesResult = await this.dbSvc.getLegacyRoles(interaction.guild.id);
+    const legacyRoles = legacyRolesResult.data;
+    
+    if (legacyRoles && legacyRoles.length > 0) {
+      await interaction.reply({
+        content: 'You must migrate or remove the legacy rule(s) for this server before adding new rules. Use /setup migrate-legacy-rule or /setup remove-legacy-rule.',
+        flags: MessageFlags.Ephemeral
+      });
+      return;
+    }
+    
+    const channel = interaction.options.getChannel('channel');
+    if (!channel) {
+      await interaction.reply({
+        content: 'Channel not found or not specified.',
+        flags: MessageFlags.Ephemeral
+      });
+      return;
+    }
+    
+    const role = interaction.options.getRole('role');
+    if (!role) {
+      await interaction.reply({
+        content: 'Role not found or not specified.',
+        flags: MessageFlags.Ephemeral
+      });
+      return;
+    }
+    
+    const slug = interaction.options.getString('slug') || null;
+    const attrKey = interaction.options.getString('attribute_key') || null;
+    const attrVal = interaction.options.getString('attribute_value') || null;
+    const minItems = interaction.options.getInteger('min_items') || null;
+    
+    // Defer the reply early to prevent timeout
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+    
+    const rule = await this.dbSvc.addRoleMapping(
+      interaction.guild.id,
+      interaction.guild.name,
+      channel.id,
+      slug,
+      role.id,
+      attrKey,
+      attrVal,
+      minItems
+    );
+    
+    Logger.debug('addRoleMapping result:', rule);
+    const newRule = rule;
+    
+    // Check for existing Wallet Verification message in the Discord channel
+    let existingVerificationMessageId = null;
+    try {
+      if (channel.type === ChannelType.GuildText || channel.type === ChannelType.GuildAnnouncement) {
+        existingVerificationMessageId = await this.messageSvc.findExistingVerificationMessage(channel as GuildTextBasedChannel);
+      }
+    } catch (err) {
+      Logger.error('Error checking for existing Wallet Verification message in Discord channel', err);
+    }
+
+    // If we found an existing verification message, use its ID for the new rule
+    if (existingVerificationMessageId) {
+      // Update the new rule with the existing message_id
+      await this.dbSvc.updateRuleMessageId(newRule.id, existingVerificationMessageId);
+      await interaction.editReply({
+        embeds: [
+          new EmbedBuilder()
+            .setTitle('Rule Added')
+            .setDescription(`Rule for <#${channel.id}> and <@&${role.id}> added using existing verification message.`)
+            .setColor('#00FF00')
+        ]
+      });
+    } else {
+      // No existing verification message found, create a new one
+      try {
+        if (channel.type !== ChannelType.GuildText && channel.type !== ChannelType.GuildAnnouncement) {
+          await interaction.editReply({
+            content: 'Selected channel is not a text or announcement channel.'
+          });
+          return;
+        }
+        
+        const messageId = await this.messageSvc.createVerificationMessage(channel as GuildTextBasedChannel);
+        
+        // Wait for DB update to complete before replying
+        await this.dbSvc.updateRuleMessageId(newRule.id, messageId);
+        
+        // Optionally, add a short delay to ensure DB consistency
+        await new Promise(res => setTimeout(res, 100));
+        
+        await interaction.editReply({
+          embeds: [
+            new EmbedBuilder()
+              .setTitle('Rule Added')
+              .setDescription(`Rule for <#${channel.id}> and <@&${role.id}> added with new verification message.`)
+              .setColor('#00FF00')
+          ]
+        });
+      } catch (err) {
+        Logger.error('Failed to send Verify Now message', err);
+        await interaction.editReply({
+          content: 'Failed to send Verify Now message. Please check my permissions and try again.'
+        });
+        return;
+      }
+    }
+  }
+
+  async handleRemoveRule(interaction: ChatInputCommandInteraction): Promise<void> {
+    const ruleId = interaction.options.getInteger('rule_id');
+    
+    // Defer the reply early to prevent timeout
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+    
+    try {
+      await this.dbSvc.deleteRoleMapping(String(ruleId), interaction.guild.id);
+      await interaction.editReply({
+        embeds: [
+          new EmbedBuilder()
+            .setTitle('Rule Removed')
+            .setDescription(`Rule ID ${ruleId} removed.`)
+            .setColor('#FF0000')
+        ]
+      });
+    } catch (err) {
+      await interaction.editReply({
+        content: `Error: ${err.message}`
+      });
+    }
+  }
+
+  async handleListRules(interaction: ChatInputCommandInteraction): Promise<void> {
+    // Defer the reply early to prevent timeout
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+    
+    const rules = await this.dbSvc.getAllRulesWithLegacy(
+      interaction.guild.id
+    );
+    
+    let desc = rules.length
+      ? rules.map(r =>
+          r.legacy
+            ? `[LEGACY] Rule: <@&${r.role_id}> (from legacy setup, please migrate or remove)`
+            : `ID: ${r.id} | Channel: <#${r.channel_id}> | Role: <@&${r.role_id}> | Slug: ${r.slug || 'ALL'} | Attr: ${r.attribute_key || '-'}=${r.attribute_value || '-'} | Min: ${r.min_items || 0}`
+        ).join('\n')
+      : 'No rules found.';
+      
+    if (rules.some(r => r.legacy)) {
+      desc +=
+        '\n\n⚠️ [LEGACY] rules are from the old setup and may assign outdated roles. Please migrate to the new rules system and remove legacy rules.';
+    }
+    
+    await interaction.editReply({
+      embeds: [
+        new EmbedBuilder()
+          .setTitle('Verification Rules')
+          .setDescription(desc)
+          .setColor('#C3FF00')
+      ]
+    });
+  }
+
+  async handleRemoveLegacyRule(interaction: ChatInputCommandInteraction): Promise<void> {
+    // Defer the reply early to prevent timeout
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+    
+    const legacyRolesResult = await this.dbSvc.getLegacyRoles(interaction.guild.id);
+    const legacyRoles = legacyRolesResult.data;
+    
+    if (!legacyRoles || legacyRoles.length === 0) {
+      await interaction.editReply({
+        content: 'No legacy roles found for this server. Nothing to remove.'
+      });
+      return;
+    }
+    
+    await this.dbSvc.removeAllLegacyRoles(interaction.guild.id);
+    
+    await interaction.editReply({
+      content: `Removed ${legacyRoles.length} legacy rule(s).`
+    });
+  }
+
+  async handleMigrateLegacyRule(interaction: ChatInputCommandInteraction): Promise<void> {
+    const channel = interaction.options.getChannel('channel');
+    if (!channel) {
+      await interaction.reply({
+        content: 'Channel not found or not specified.',
+        flags: MessageFlags.Ephemeral
+      });
+      return;
+    }
+    
+    // Defer the reply early to prevent timeout
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+    
+    // Get legacy roles
+    const legacyRolesResult = await this.dbSvc.getLegacyRoles(interaction.guild.id);
+    const legacyRoles = legacyRolesResult.data;
+    
+    if (!legacyRoles || legacyRoles.length === 0) {
+      await interaction.editReply({
+        content: 'No legacy roles found for this server. Nothing to migrate.'
+      });
+      return;
+    }
+    
+    // For each legacy role, create a new rule in verifier_rules
+    const created = [];
+    const alreadyPresent = [];
+    
+    for (const legacy of legacyRoles) {
+      const exists = await this.dbSvc.ruleExists(
+        interaction.guild.id,
+        channel.id,
+        legacy.role_id,
+        'ALL'
+      );
+      
+      if (exists) {
+        alreadyPresent.push(`<@&${legacy.role_id}>`);
+        continue;
+      }
+      
+      try {
+        await this.dbSvc.addRoleMapping(
+          interaction.guild.id,
+          interaction.guild.name,
+          channel.id,
+          'ALL', // slug
+          legacy.role_id,
+          null, // attribute_key
+          null, // attribute_value
+          1    // min_items (set to 1 for migration)
+        );
+        created.push(`<@&${legacy.role_id}>`);
+      } catch (e) {
+        // Optionally handle per-role errors
+        Logger.error(`Error migrating role ${legacy.role_id}:`, e);
+      }
+    }
+    
+    await this.dbSvc.removeAllLegacyRoles(interaction.guild.id);
+    
+    let msg = '';
+    if (created.length) msg += `Migrated legacy rule(s) to new rule(s) for channel <#${channel.id}>: ${created.join(', ')}. `;
+    if (alreadyPresent.length) msg += `Legacy rule(s) already exist as new rule(s) for channel <#${channel.id}>: ${alreadyPresent.join(', ')}. `;
+    msg += 'Removed legacy rule(s).';
+    
+    await interaction.editReply({
+      content: msg
+    });
+  }
+}

--- a/backend/src/services/discord-message.service.ts
+++ b/backend/src/services/discord-message.service.ts
@@ -1,0 +1,110 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { GuildTextBasedChannel, EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle, Client } from 'discord.js';
+
+@Injectable()
+export class DiscordMessageService {
+  private client: Client | null = null;
+
+  /**
+   * Initialize the service with the Discord client.
+   */
+  initialize(client: Client): void {
+    this.client = client;
+  }
+
+  constructor() {}
+
+  /**
+   * Searches for existing Wallet Verification messages in a Discord channel.
+   * Looks for messages with "Wallet Verification" embed title and "Verify Now" button.
+   * @param channel - The Discord channel to search in
+   * @returns The message ID of the existing verification message, or null if not found
+   */
+  async findExistingVerificationMessage(channel: GuildTextBasedChannel): Promise<string | null> {
+    try {
+      // Fetch recent messages from the channel (last 100 messages should be enough)
+      const messages = await channel.messages.fetch({ limit: 100 });
+      
+      for (const [messageId, message] of messages) {
+        // Check if message is from our bot
+        if (message.author.id !== this.client?.user?.id) continue;
+        
+        // Check if message has embeds with "Wallet Verification" title
+        if (message.embeds.length > 0) {
+          const embed = message.embeds[0];
+          if (embed.title === 'Wallet Verification') {
+            // Check if message has components with "Verify Now" button
+            if (message.components.length > 0) {
+              const actionRow = message.components[0];
+              if (actionRow.type === 1 && 'components' in actionRow) { // ActionRowBuilder type
+                const components = actionRow.components;
+                if (components.length > 0) {
+                  const button = components[0];
+                  // Check if it's a button component and has the right properties
+                  if (button.type === 2) { // ButtonComponent type
+                    const buttonComponent = button as any; // Type assertion to access button properties
+                    if ((buttonComponent.customId === 'requestVerification' && buttonComponent.label === 'Verify Now') ||
+                        (buttonComponent.style === ButtonStyle.Link && buttonComponent.label === 'Verify Now')) {
+                      Logger.debug(`Found existing Wallet Verification message: ${messageId}`);
+                      return messageId;
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      
+      Logger.debug('No existing Wallet Verification message found in channel');
+      return null;
+    } catch (error) {
+      Logger.error('Error searching for existing verification message:', error);
+      return null;
+    }
+  }
+
+  /**
+   * Creates a new verification message in the specified channel
+   * @param channel - The Discord channel to send the message to
+   * @returns The message ID of the created verification message
+   */
+  async createVerificationMessage(channel: GuildTextBasedChannel): Promise<string> {
+    const verifyEmbed = new EmbedBuilder()
+      .setTitle('Wallet Verification')
+      .setDescription('Verify your identity using your EVM wallet by clicking the button below.')
+      .setColor('#00FF00');
+      
+    const verifyButton = new ActionRowBuilder<ButtonBuilder>()
+      .setComponents(
+        new ButtonBuilder()
+          .setCustomId('requestVerification')
+          .setLabel('Verify Now')
+          .setStyle(ButtonStyle.Primary)
+      );
+
+    const sentMessage = await channel.send({
+      embeds: [verifyEmbed],
+      components: [verifyButton],
+    });
+
+    Logger.debug(`Created new verification message: ${sentMessage.id}`);
+    return sentMessage.id;
+  }
+
+  /**
+   * Checks if a Discord message still exists in the channel
+   * @param channel - The Discord channel to check
+   * @param messageId - The ID of the message to verify
+   * @returns True if the message exists, false otherwise
+   */
+  async verifyMessageExists(channel: GuildTextBasedChannel, messageId: string): Promise<boolean> {
+    try {
+      await channel.messages.fetch(messageId);
+      return true;
+    } catch (error) {
+      // Message not found (deleted, etc.)
+      return false;
+    }
+  }
+}

--- a/backend/src/services/discord-verification.service.ts
+++ b/backend/src/services/discord-verification.service.ts
@@ -1,0 +1,262 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ButtonInteraction, EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle, CacheType, Client, MessageFlags } from 'discord.js';
+import { DbService } from './db.service';
+import { NonceService } from './nonce.service';
+
+const EXPIRY = Number(process.env.NONCE_EXPIRY);
+
+@Injectable()
+export class DiscordVerificationService {
+  private client: Client | null = null;
+  
+  tempMessages: {
+    [nonce: string]: ButtonInteraction<CacheType>;
+  } = {};
+
+  /**
+   * Initialize the service with the Discord client.
+   */
+  initialize(client: Client): void {
+    this.client = client;
+  }
+
+  constructor(
+    private readonly dbSvc: DbService,
+    private readonly nonceSvc: NonceService
+  ) {}
+
+  /**
+   * Requests verification from the user by sending a verification link.
+   * @param interaction - The button interaction triggered by the user.
+   */
+  async requestVerification(interaction: ButtonInteraction<CacheType>): Promise<void> {
+    try {
+      // Defer the reply early to prevent timeout
+      await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+      
+      const guild = interaction.guild;
+      if (!guild) throw new Error('Guild not found');
+      
+      const channel = interaction.channel;
+      if (!channel || !('id' in channel)) throw new Error('Channel not found');
+      
+      // Try to get the correct roleId (legacy or new)
+      let roleId: string | null = null;
+      try {
+        roleId = await this.getVerificationRoleId(guild.id, channel.id, interaction.message.id);
+      } catch (err) {
+        Logger.error('Error fetching verification roleId', err);
+      }
+      
+      Logger.debug('requestVerification: resolved roleId:', roleId);
+      
+      if (!roleId) throw new Error('Verification role not found for this message.');
+      
+      const role = guild.roles.cache.get(roleId);
+      if (!role) throw new Error('Role not found');
+
+      // Check if user is already verified
+      // const userServers = await this.dbSvc.getUserServers(interaction.user.id);
+      // if (userServers?.servers?.[guild.id]) {
+      //   await interaction.editReply({
+      //     embeds: [
+      //       new EmbedBuilder()
+      //         .setTitle('Verification Request')
+      //         .setDescription('You have already been verified in this server.')
+      //         .setColor('#FF0000')
+      //     ]
+      //   });
+      //   
+      //   return;
+      // }
+
+      // Create a nonce with message and channel info
+      const expiry = Math.floor((Date.now() + EXPIRY) / 1000);
+      const nonce = await this.nonceSvc.createNonce(
+        interaction.user.id,
+        interaction.message.id,
+        channel.id
+      );
+      
+      Logger.debug(`Created nonce with messageId: ${interaction.message.id}, channelId: ${channel.id}`);
+      
+      // Encode the payload (keeping legacy format for compatibility)
+      const payloadArr = [
+        interaction.user.id,
+        interaction.user.tag,
+        interaction.user.avatarURL(),
+        interaction.guild.id,
+        interaction.guild.name,
+        interaction.guild.iconURL(),
+        role.id, // TODO(v3): deprecated, remove when legacy buttons are phased out
+        role.name, // TODO(v3): deprecated, remove when legacy buttons are phased out
+        nonce,
+        expiry,
+      ];
+      
+      const encoded = Buffer.from(JSON.stringify(payloadArr)).toString('base64');
+      const url = `${process.env.BASE_URL}/verify/${encoded}`;
+
+      // Reply to the interaction
+      await interaction.editReply({
+        embeds: [
+          new EmbedBuilder()
+            .setTitle('Wallet Verification')
+            .setDescription(`Verify your identity using your EVM wallet by clicking the unique link below. This link is personal and expires <t:${expiry}:R>.`)
+            .setColor('#00FF00')
+        ],
+        components: [
+          new ActionRowBuilder<ButtonBuilder>()
+            .setComponents(
+              new ButtonBuilder()
+                .setLabel('Verify Now')
+                .setURL(url)
+                .setStyle(ButtonStyle.Link)
+            )
+        ]
+      });
+
+      // Store the temp message
+      this.tempMessages[nonce] = interaction;
+      
+      Logger.debug(`Sent verification link to ${interaction.user.tag}`);
+    } catch (error) {
+      Logger.error('Error in requestVerification:', error);
+      if (interaction.deferred) {
+        await interaction.editReply({
+          content: `Error: ${error.message}`
+        });
+      } else {
+        try {
+          await interaction.reply({
+            content: `Error: ${error.message}`,
+            flags: MessageFlags.Ephemeral
+          });
+        } catch (replyError) {
+          Logger.error('Failed to reply with error:', replyError);
+        }
+      }
+    }
+  }
+
+  /**
+   * Adds a role to a user in a guild.
+   * 
+   * @param userId - The ID of the user.
+   * @param roleId - The ID of the role to be added.
+   * @param guildId - The ID of the guild.
+   * @throws Error if the Discord bot is not initialized, guild is not found, or member is not found.
+   */
+  async addUserRole(
+    userId: string, 
+    roleId: string,
+    guildId: string,
+    address: string,
+    nonce: string
+  ): Promise<void> {
+    if (!this.client) throw new Error('Discord bot not initialized');
+
+    const guild = this.client.guilds.cache.get(guildId);
+    if (!guild) throw new Error('Guild not found');
+
+    Logger.debug('addUserRole: roleId from payload:', roleId);
+    Logger.debug('addUserRole: guild roles:', guild.roles.cache.map(r => ({ id: r.id, name: r.name })));
+
+    const member = await guild.members.fetch(userId);
+    if (!member) throw new Error('Member not found');
+
+    const role = guild.roles.cache.get(roleId);
+    if (!role) throw new Error('Role not found');
+      
+    const storedInteraction = this.tempMessages[nonce];
+    if (!storedInteraction) {
+      throw new Error('No stored interaction found for this nonce');
+    }
+
+    try {
+      await member.roles.add(role);
+      await this.dbSvc.addServerToUser(
+        userId, 
+        guildId, 
+        role.name,
+        address
+      );
+
+      // Reply to the interaction
+      await storedInteraction.editReply({
+        embeds: [
+          new EmbedBuilder()
+            .setTitle('Verification Successful')
+            .setDescription(`You have been successfully verified in ${guild.name}.`)
+            .setColor('#00FF00')
+        ],
+      });
+      
+    } catch (error) {
+      Logger.error('Error in addUserRole:', error);
+
+      // Reply to the interaction
+      await storedInteraction.editReply({
+        embeds: [
+          new EmbedBuilder()
+            .setTitle('Verification Failed')
+            .setDescription(`An error occurred while verifying your identity. Please try again later.`)
+            .setColor('#FF0000')
+        ],
+      });
+
+    } finally {
+      
+      // Delete the temp message
+      delete this.tempMessages[nonce];
+    }
+  }
+
+  /**
+   * Throws an error by editing the stored interaction with an error message.
+   * @param nonce - The nonce associated with the stored interaction.
+   * @param message - The error message to display.
+   */
+  async throwError(nonce: string, message: string): Promise<void> {
+    const storedInteraction = this.tempMessages[nonce];
+    if (!storedInteraction) {
+      Logger.warn(`No stored interaction found for nonce: ${nonce}`);
+      return;
+    }
+
+    try {
+      // Check if interaction is still valid
+      if (!storedInteraction.isRepliable()) {
+        Logger.warn(`Interaction for nonce ${nonce} is no longer repliable`);
+        return;
+      }
+      
+      await storedInteraction.editReply({
+        embeds: [
+          new EmbedBuilder()
+            .setTitle('Verification Failed')
+            .setDescription(`${message}`)
+            .setColor('#FF0000')
+        ],
+      });
+    } catch (error) {
+      Logger.error(`Failed to edit reply for nonce ${nonce}:`, error);
+    } finally {
+      // Clean up the stored interaction
+      delete this.tempMessages[nonce];
+    }
+  }
+
+  /**
+   * Helper to get the correct roleId for verification, supporting both legacy and new rules.
+   */
+  async getVerificationRoleId(guildId: string, channelId: string, messageId: string): Promise<string | null> {
+    // Try legacy first
+    const legacyRoleId = await this.dbSvc.getServerRole(guildId);
+    if (legacyRoleId) return legacyRoleId;
+    // Try new rules
+    const rule = await this.dbSvc.findRuleByMessageId(guildId, channelId, messageId);
+    if (rule && rule.role_id) return rule.role_id;
+    return null;
+  }
+}

--- a/backend/src/services/discord.service.ts
+++ b/backend/src/services/discord.service.ts
@@ -4,6 +4,9 @@ import { ActionRowBuilder, ButtonBuilder, ButtonInteraction, ButtonStyle, CacheT
 
 import { NonceService } from '@/services/nonce.service';
 import { DbService } from '@/services/db.service';
+import { DiscordMessageService } from '@/services/discord-message.service';
+import { DiscordVerificationService } from '@/services/discord-verification.service';
+import { DiscordCommandsService } from '@/services/discord-commands.service';
 
 import dotenv from 'dotenv';
 dotenv.config();
@@ -15,14 +18,13 @@ export class DiscordService {
 
   private client: Client | null = null;
   private rest = new REST({ version: '10' }).setToken(process.env.DISCORD_BOT_TOKEN);
-
-  tempMessages: {
-    [nonce: string]: ButtonInteraction<CacheType>;
-  } = {};
   
   constructor(
     @Inject(NonceService) private nonceSvc: NonceService,
     private readonly dbSvc: DbService,
+    private readonly discordMessageSvc: DiscordMessageService,
+    private readonly discordVerificationSvc: DiscordVerificationService,
+    private readonly discordCommandsSvc: DiscordCommandsService,
   ) {
     if (Number(process.env.DISCORD)) {
       this.initializeBot()
@@ -43,6 +45,10 @@ export class DiscordService {
 
       this.client.on(Events.ClientReady, (readyClient) => {
         Logger.debug('Discord bot initialized.', readyClient.user.tag);
+        // Initialize the new services with the client
+        this.discordMessageSvc.initialize(this.client);
+        this.discordVerificationSvc.initialize(this.client);
+        this.discordCommandsSvc.initialize(this.client);
         resolve();
       });
 
@@ -72,7 +78,7 @@ export class DiscordService {
       // Handle button interactions (user)
       if (interaction.isButton()) {
         if (interaction.customId === 'requestVerification') {
-          await this.requestVerification(interaction);
+          await this.discordVerificationSvc.requestVerification(interaction);
         }
       }
     });
@@ -87,404 +93,30 @@ export class DiscordService {
       const sub = interaction.options.getSubcommand();
       
       if (sub === 'add-rule') {
-        // Check if there are legacy roles that need to be migrated
-        const legacyRolesResult = await this.dbSvc.getLegacyRoles(interaction.guild.id);
-        const legacyRoles = legacyRolesResult.data;
-        
-        if (legacyRoles && legacyRoles.length > 0) {
-          await interaction.reply({
-            content: 'You must migrate or remove the legacy rule(s) for this server before adding new rules. Use /setup migrate-legacy-rule or /setup remove-legacy-rule.',
-            flags: MessageFlags.Ephemeral
-          });
-          return;
-        }
-        
-        const channel = interaction.options.getChannel('channel');
-        if (!channel) {
-          await interaction.reply({
-            content: 'Channel not found or not specified.',
-            flags: MessageFlags.Ephemeral
-          });
-          return;
-        }
-        
-        const role = interaction.options.getRole('role');
-        if (!role) {
-          await interaction.reply({
-            content: 'Role not found or not specified.',
-            flags: MessageFlags.Ephemeral
-          });
-          return;
-        }
-        
-        const slug = interaction.options.getString('slug') || null;
-        const attrKey = interaction.options.getString('attribute_key') || null;
-        const attrVal = interaction.options.getString('attribute_value') || null;
-        const minItems = interaction.options.getInteger('min_items') || null;
-        
-        // Defer the reply early to prevent timeout
-        await interaction.deferReply({ flags: MessageFlags.Ephemeral });
-        
-        const rule = await this.dbSvc.addRoleMapping(
-          interaction.guild.id,
-          interaction.guild.name,
-          channel.id,
-          slug,
-          role.id,
-          attrKey,
-          attrVal,
-          minItems
-        );
-        
-        Logger.debug('addRoleMapping result:', rule);
-        const newRule = rule;
-        
-        // Check for existing Wallet Verification message in the Discord channel
-        let existingVerificationMessageId = null;
-        try {
-          if (channel.type === ChannelType.GuildText || channel.type === ChannelType.GuildAnnouncement) {
-            existingVerificationMessageId = await this.findExistingVerificationMessage(channel as GuildTextBasedChannel);
-          }
-        } catch (err) {
-          Logger.error('Error checking for existing Wallet Verification message in Discord channel', err);
-        }
-
-        // If we found an existing verification message, use its ID for the new rule
-        if (existingVerificationMessageId) {
-          // Update the new rule with the existing message_id
-          await this.dbSvc.updateRuleMessageId(newRule.id, existingVerificationMessageId);
-          await interaction.editReply({
-            embeds: [
-              new EmbedBuilder()
-                .setTitle('Rule Added')
-                .setDescription(`Rule for <#${channel.id}> and <@&${role.id}> added using existing verification message.`)
-                .setColor('#00FF00')
-            ]
-          });
-        } else {
-          // No existing verification message found, create a new one
-          const verifyEmbed = new EmbedBuilder()
-            .setTitle('Wallet Verification')
-            .setDescription('Verify your identity using your EVM wallet by clicking the button below.')
-            .setColor('#00FF00');
-            
-          const verifyButton = new ActionRowBuilder<ButtonBuilder>()
-            .setComponents(
-              new ButtonBuilder()
-                .setCustomId('requestVerification')
-                .setLabel('Verify Now')
-                .setStyle(ButtonStyle.Primary)
-            );
-            
-          try {
-            if (channel.type !== ChannelType.GuildText && channel.type !== ChannelType.GuildAnnouncement) {
-              await interaction.editReply({
-                content: 'Selected channel is not a text or announcement channel.'
-              });
-              return;
-            }
-            
-            const sentMessage = await (channel as GuildTextBasedChannel).send({
-              embeds: [verifyEmbed],
-              components: [verifyButton],
-            });
-            
-            // Wait for DB update to complete before replying
-            await this.dbSvc.updateRuleMessageId(newRule.id, sentMessage.id);
-            
-            // Optionally, add a short delay to ensure DB consistency
-            await new Promise(res => setTimeout(res, 100));
-            
-            await interaction.editReply({
-              embeds: [
-                new EmbedBuilder()
-                  .setTitle('Rule Added')
-                  .setDescription(`Rule for <#${channel.id}> and <@&${role.id}> added with new verification message.`)
-                  .setColor('#00FF00')
-              ]
-            });
-          } catch (err) {
-            Logger.error('Failed to send Verify Now message', err);
-            await interaction.editReply({
-              content: 'Failed to send Verify Now message. Please check my permissions and try again.'
-            });
-            return;
-          }
-        }
+        await this.discordCommandsSvc.handleAddRule(interaction);
       } else if (sub === 'remove-rule') {
-        const ruleId = interaction.options.getInteger('rule_id');
-        
-        // Defer the reply early to prevent timeout
-        await interaction.deferReply({ flags: MessageFlags.Ephemeral });
-        
-        try {
-          await this.dbSvc.deleteRoleMapping(String(ruleId), interaction.guild.id);
-          await interaction.editReply({
-            embeds: [
-              new EmbedBuilder()
-                .setTitle('Rule Removed')
-                .setDescription(`Rule ID ${ruleId} removed.`)
-                .setColor('#FF0000')
-            ]
-          });
-        } catch (err) {
-          await interaction.editReply({
-            content: `Error: ${err.message}`
-          });
-        }
+        await this.discordCommandsSvc.handleRemoveRule(interaction);
       } else if (sub === 'list-rules') {
-        // No channel option: list all rules for the server
-        
-        // Defer the reply early to prevent timeout
-        await interaction.deferReply({ flags: MessageFlags.Ephemeral });
-        
-        const rules = await this.dbSvc.getAllRulesWithLegacy(
-          interaction.guild.id
-        );
-        
-        let desc = rules.length
-          ? rules.map(r =>
-              r.legacy
-                ? `[LEGACY] Rule: <@&${r.role_id}> (from legacy setup, please migrate or remove)`
-                : `ID: ${r.id} | Channel: <#${r.channel_id}> | Role: <@&${r.role_id}> | Slug: ${r.slug || 'ALL'} | Attr: ${r.attribute_key || '-'}=${r.attribute_value || '-'} | Min: ${r.min_items || 0}`
-            ).join('\n')
-          : 'No rules found.';
-          
-        if (rules.some(r => r.legacy)) {
-          desc +=
-            '\n\n⚠️ [LEGACY] rules are from the old setup and may assign outdated roles. Please migrate to the new rules system and remove legacy rules.';
-        }
-        
-        await interaction.editReply({
-          embeds: [
-            new EmbedBuilder()
-              .setTitle('Verification Rules')
-              .setDescription(desc)
-              .setColor('#C3FF00')
-          ]
-        });
+        await this.discordCommandsSvc.handleListRules(interaction);
       } else if (sub === 'remove-legacy-rule') {
-        // Remove all legacy roles for this guild using DbService
-        
-        // Defer the reply early to prevent timeout
-        await interaction.deferReply({ flags: MessageFlags.Ephemeral });
-        
-        const legacyRolesResult = await this.dbSvc.getLegacyRoles(interaction.guild.id);
-        const legacyRoles = legacyRolesResult.data;
-        
-        if (!legacyRoles || legacyRoles.length === 0) {
-          await interaction.editReply({
-            content: 'No legacy roles found for this server. Nothing to remove.'
-          });
-          return;
-        }
-        
-        await this.dbSvc.removeAllLegacyRoles(interaction.guild.id);
-        
-        await interaction.editReply({
-          content: `Removed ${legacyRoles.length} legacy rule(s).`
-        });
+        await this.discordCommandsSvc.handleRemoveLegacyRule(interaction);
       } else if (sub === 'migrate-legacy-rule') {
-        const channel = interaction.options.getChannel('channel');
-        if (!channel) {
-          await interaction.reply({
-            content: 'Channel not found or not specified.',
-            flags: MessageFlags.Ephemeral
-          });
-          return;
-        }
-        
-        // Defer the reply early to prevent timeout
-        await interaction.deferReply({ flags: MessageFlags.Ephemeral });
-        
-        // Get legacy roles
-        const legacyRolesResult = await this.dbSvc.getLegacyRoles(interaction.guild.id);
-        const legacyRoles = legacyRolesResult.data;
-        
-        if (!legacyRoles || legacyRoles.length === 0) {
-          await interaction.editReply({
-            content: 'No legacy roles found for this server. Nothing to migrate.'
-          });
-          return;
-        }
-        
-        // For each legacy role, create a new rule in verifier_rules
-        const created = [];
-        const alreadyPresent = [];
-        
-        for (const legacy of legacyRoles) {
-          const exists = await this.dbSvc.ruleExists(
-            interaction.guild.id,
-            channel.id,
-            legacy.role_id,
-            'ALL'
-          );
-          
-          if (exists) {
-            alreadyPresent.push(`<@&${legacy.role_id}>`);
-            continue;
-          }
-          
-          try {
-            await this.dbSvc.addRoleMapping(
-              interaction.guild.id,
-              interaction.guild.name,
-              channel.id,
-              'ALL', // slug
-              legacy.role_id,
-              null, // attribute_key
-              null, // attribute_value
-              1    // min_items (set to 1 for migration)
-            );
-            created.push(`<@&${legacy.role_id}>`);
-          } catch (e) {
-            // Optionally handle per-role errors
-            Logger.error(`Error migrating role ${legacy.role_id}:`, e);
-          }
-        }
-        
-        await this.dbSvc.removeAllLegacyRoles(interaction.guild.id);
-        
-        let msg = '';
-        if (created.length) msg += `Migrated legacy rule(s) to new rule(s) for channel <#${channel.id}>: ${created.join(', ')}. `;
-        if (alreadyPresent.length) msg += `Legacy rule(s) already exist as new rule(s) for channel <#${channel.id}>: ${alreadyPresent.join(', ')}. `;
-        msg += 'Removed legacy rule(s).';
-        
-        await interaction.editReply({
-          content: msg
-        });
+        await this.discordCommandsSvc.handleMigrateLegacyRule(interaction);
       }
     } catch (error) {
-      console.error(error);
-      // Check if we've already replied or deferred
-      if (interaction.deferred) {
-        await interaction.editReply({
-          content: `Error: ${error.message}`
-        });
-      } else {
-        try {
-          await interaction.reply({
-            content: `Error: ${error.message}`,
-            flags: MessageFlags.Ephemeral
-          });
-        } catch (replyError) {
-          Logger.error('Failed to reply with error:', replyError);
-        }
-      }
+      Logger.error('Error in handleSetup:', error);
+      await interaction.reply({
+        content: 'An error occurred while processing your request.',
+        flags: MessageFlags.Ephemeral
+      });
     }
   }
-
   /**
    * Requests verification from the user by sending a verification link.
    * @param interaction - The button interaction triggered by the user.
    */
   async requestVerification(interaction: ButtonInteraction<CacheType>): Promise<void> {
-    try {
-      // Defer the reply early to prevent timeout
-      await interaction.deferReply({ flags: MessageFlags.Ephemeral });
-      
-      const guild = interaction.guild;
-      if (!guild) throw new Error('Guild not found');
-      
-      const channel = interaction.channel;
-      if (!channel || !('id' in channel)) throw new Error('Channel not found');
-      
-      // Try to get the correct roleId (legacy or new)
-      let roleId: string | null = null;
-      try {
-        roleId = await this.getVerificationRoleId(guild.id, channel.id, interaction.message.id);
-      } catch (err) {
-        Logger.error('Error fetching verification roleId', err);
-      }
-      
-      Logger.debug('requestVerification: resolved roleId:', roleId);
-      if (!roleId) throw new Error('Verification role not found for this message.');
-      
-      const role = guild.roles.cache.get(roleId);
-      if (!role) throw new Error('Role not found');
-
-      // Check if user is already verified
-      // const userServers = await this.dbSvc.getUserServers(interaction.user.id);
-      // if (userServers?.servers?.[guild.id]) {
-      //   await interaction.editReply({
-      //     embeds: [
-      //       new EmbedBuilder()
-      //         .setTitle('Verification Request')
-      //         .setDescription('You have already been verified in this server.')
-      //         .setColor('#FF0000')
-      //     ]
-      //   });
-      //   
-      //   return;
-      // }
-
-      // Create a nonce with message and channel info
-      const expiry = Math.floor((Date.now() + EXPIRY) / 1000);
-      const nonce = await this.nonceSvc.createNonce(
-        interaction.user.id,
-        interaction.message.id,
-        channel.id
-      );
-      
-      Logger.debug(`Created nonce with messageId: ${interaction.message.id}, channelId: ${channel.id}`);
-      
-      // Encode the payload (keeping legacy format for compatibility)
-      const payloadArr = [
-        interaction.user.id,
-        interaction.user.tag,
-        interaction.user.avatarURL(),
-        interaction.guild.id,
-        interaction.guild.name,
-        interaction.guild.iconURL(),
-        role.id, // TODO(v3): deprecated, remove when legacy buttons are phased out
-        role.name, // TODO(v3): deprecated, remove when legacy buttons are phased out
-        nonce,
-        expiry,
-      ];
-      
-      const encoded = Buffer.from(JSON.stringify(payloadArr)).toString('base64');
-      const url = `${process.env.BASE_URL}/verify/${encoded}`;
-
-      // Reply to the interaction
-      await interaction.editReply({
-        embeds: [
-          new EmbedBuilder()
-            .setTitle('Wallet Verification')
-            .setDescription(`Verify your identity using your EVM wallet by clicking the unique link below. This link is personal and expires <t:${expiry}:R>.`)
-            .setColor('#00FF00')
-        ],
-        components: [
-          new ActionRowBuilder<ButtonBuilder>()
-            .setComponents(
-              new ButtonBuilder()
-                .setLabel('Verify Now')
-                .setURL(url)
-                .setStyle(ButtonStyle.Link)
-            )
-        ]
-      });
-
-      // Store the temp message
-      this.tempMessages[nonce] = interaction;
-
-      Logger.debug(`Sent verification link to ${interaction.user.tag}`);
-    } catch (error) {
-      console.error(error);
-      if (interaction.deferred) {
-        await interaction.editReply({
-          content: `Error: ${error.message}`
-        });
-      } else {
-        try {
-          await interaction.reply({
-            content: `Error: ${error.message}`,
-            flags: MessageFlags.Ephemeral
-          });
-        } catch (replyError) {
-          Logger.error('Failed to reply with error:', replyError);
-        }
-      }
-    }
+    return this.discordVerificationSvc.requestVerification(interaction);
   }
 
   /**
@@ -502,62 +134,7 @@ export class DiscordService {
     address: string,
     nonce: string
   ): Promise<void> {
-    if (!this.client) throw new Error('Discord bot not initialized');
-
-    const guild = this.client.guilds.cache.get(guildId);
-    if (!guild) throw new Error('Guild not found');
-
-    Logger.debug('addUserRole: roleId from payload:', roleId);
-    Logger.debug('addUserRole: guild roles:', guild.roles.cache.map(r => ({ id: r.id, name: r.name })));
-
-    const member = await guild.members.fetch(userId);
-    if (!member) throw new Error('Member not found');
-
-    const role = guild.roles.cache.get(roleId);
-    if (!role) throw new Error('Role not found');
-      
-    const storedInteraction = this.tempMessages[nonce];
-    if (!storedInteraction) {
-      throw new Error('No stored interaction found for this nonce');
-    }
-
-    try {
-      await member.roles.add(role);
-      await this.dbSvc.addServerToUser(
-        userId, 
-        guildId, 
-        role.name,
-        address
-      );
-
-      // Reply to the interaction
-      await storedInteraction.editReply({
-        embeds: [
-          new EmbedBuilder()
-            .setTitle('Verification Successful')
-            .setDescription(`You have been successfully verified in ${guild.name}.`)
-            .setColor('#00FF00')
-        ],
-      });
-      
-    } catch (error) {
-      console.error(error);
-
-      // Reply to the interaction
-      await storedInteraction.editReply({
-        embeds: [
-          new EmbedBuilder()
-            .setTitle('Verification Failed')
-            .setDescription(`An error occurred while verifying your identity. Please try again later.`)
-            .setColor('#FF0000')
-        ],
-      });
-
-    } finally {
-      
-      // Delete the temp message
-      delete this.tempMessages[nonce];
-    }
+    return this.discordVerificationSvc.addUserRole(userId, roleId, guildId, address, nonce);
   }
 
   /**
@@ -617,46 +194,14 @@ export class DiscordService {
    * @param message - The error message to display.
    */
   async throwError(nonce: string, message: string): Promise<void> {
-    const storedInteraction = this.tempMessages[nonce];
-    if (!storedInteraction) {
-      Logger.warn(`No stored interaction found for nonce: ${nonce}`);
-      return;
-    }
-
-    try {
-      // Check if interaction is still valid
-      if (!storedInteraction.isRepliable()) {
-        Logger.warn(`Interaction for nonce ${nonce} is no longer repliable`);
-        return;
-      }
-      
-      await storedInteraction.editReply({
-        embeds: [
-          new EmbedBuilder()
-            .setTitle('Verification Failed')
-            .setDescription(`${message}`)
-            .setColor('#FF0000')
-        ],
-      });
-    } catch (error) {
-      Logger.error(`Failed to edit reply for nonce ${nonce}:`, error);
-    } finally {
-      // Clean up the stored interaction
-      delete this.tempMessages[nonce];
-    }
+    return this.discordVerificationSvc.throwError(nonce, message);
   }
 
   /**
    * Helper to get the correct roleId for verification, supporting both legacy and new rules.
    */
   async getVerificationRoleId(guildId: string, channelId: string, messageId: string): Promise<string | null> {
-    // Try legacy first
-    const legacyRoleId = await this.dbSvc.getServerRole(guildId);
-    if (legacyRoleId) return legacyRoleId;
-    // Try new rules
-    const rule = await this.dbSvc.findRuleByMessageId(guildId, channelId, messageId);
-    if (rule && rule.role_id) return rule.role_id;
-    return null;
+    return this.discordVerificationSvc.getVerificationRoleId(guildId, channelId, messageId);
   }
 
   /**
@@ -666,46 +211,6 @@ export class DiscordService {
    * @returns The message ID of the existing verification message, or null if not found
    */
   async findExistingVerificationMessage(channel: GuildTextBasedChannel): Promise<string | null> {
-    try {
-      // Fetch recent messages from the channel (last 100 messages should be enough)
-      const messages = await channel.messages.fetch({ limit: 100 });
-      
-      for (const [messageId, message] of messages) {
-        // Check if message is from our bot
-        if (message.author.id !== this.client?.user?.id) continue;
-        
-        // Check if message has embeds with "Wallet Verification" title
-        if (message.embeds.length > 0) {
-          const embed = message.embeds[0];
-          if (embed.title === 'Wallet Verification') {
-            // Check if message has components with "Verify Now" button
-            if (message.components.length > 0) {
-              const actionRow = message.components[0];
-              if (actionRow.type === 1 && 'components' in actionRow) { // ActionRowBuilder type
-                const components = actionRow.components;
-                if (components.length > 0) {
-                  const button = components[0];
-                  // Check if it's a button component and has the right properties
-                  if (button.type === 2) { // ButtonComponent type
-                    const buttonComponent = button as any; // Type assertion to access button properties
-                    if ((buttonComponent.customId === 'requestVerification' && buttonComponent.label === 'Verify Now') ||
-                        (buttonComponent.style === ButtonStyle.Link && buttonComponent.label === 'Verify Now')) {
-                      Logger.debug(`Found existing Wallet Verification message: ${messageId}`);
-                      return messageId;
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-      
-      Logger.debug('No existing Wallet Verification message found in channel');
-      return null;
-    } catch (error) {
-      Logger.error('Error searching for existing verification message:', error);
-      return null;
-    }
+    return this.discordMessageSvc.findExistingVerificationMessage(channel);
   }
 }

--- a/backend/test/discord-message.service.spec.ts
+++ b/backend/test/discord-message.service.spec.ts
@@ -1,0 +1,189 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DiscordMessageService } from '../src/services/discord-message.service';
+import { Logger } from '@nestjs/common';
+import { ButtonStyle } from 'discord.js';
+
+// Mock Logger methods to suppress error output during tests
+const loggerSpy = jest.spyOn(Logger, 'error').mockImplementation(() => {});
+const loggerDebugSpy = jest.spyOn(Logger, 'debug').mockImplementation(() => {});
+
+const mockClient = {
+  user: { id: 'bot-user-id' }
+};
+
+const mockChannel = {
+  id: 'channel-id',
+  name: 'test-channel',
+  messages: {
+    fetch: jest.fn(),
+  },
+  send: jest.fn(),
+};
+
+const mockMessage = {
+  id: 'message-id',
+  author: { id: 'bot-user-id' },
+  embeds: [
+    {
+      title: 'Wallet Verification',
+      description: 'Test description'
+    }
+  ],
+  components: [
+    {
+      type: 1, // ActionRowBuilder type
+      components: [
+        {
+          type: 2, // ButtonComponent type
+          customId: 'requestVerification',
+          label: 'Verify Now',
+          style: ButtonStyle.Primary
+        }
+      ]
+    }
+  ]
+};
+
+const mockMessagesCollection = new Map([
+  ['message-id', mockMessage]
+]);
+
+describe('DiscordMessageService', () => {
+  let service: DiscordMessageService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [DiscordMessageService],
+    }).compile();
+
+    service = module.get<DiscordMessageService>(DiscordMessageService);
+    service.initialize(mockClient as any);
+    jest.clearAllMocks();
+    loggerSpy.mockClear();
+    loggerDebugSpy.mockClear();
+  });
+
+  afterAll(() => {
+    loggerSpy.mockRestore();
+    loggerDebugSpy.mockRestore();
+  });
+
+  describe('findExistingVerificationMessage', () => {
+    it('should find existing verification message', async () => {
+      mockChannel.messages.fetch.mockResolvedValue(mockMessagesCollection);
+
+      const result = await service.findExistingVerificationMessage(mockChannel as any);
+
+      expect(result).toBe('message-id');
+      expect(mockChannel.messages.fetch).toHaveBeenCalledWith({ limit: 100 });
+    });
+
+    it('should return null when no verification message found', async () => {
+      const emptyMessages = new Map();
+      mockChannel.messages.fetch.mockResolvedValue(emptyMessages);
+
+      const result = await service.findExistingVerificationMessage(mockChannel as any);
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null when client not initialized', async () => {
+      const uninitializedService = new DiscordMessageService();
+
+      const result = await uninitializedService.findExistingVerificationMessage(mockChannel as any);
+
+      expect(result).toBeNull();
+    });
+
+    it('should handle messages from other bots', async () => {
+      const otherBotMessage = {
+        ...mockMessage,
+        author: { id: 'other-bot-id' }
+      };
+      const messagesWithOtherBot = new Map([
+        ['other-message-id', otherBotMessage]
+      ]);
+      mockChannel.messages.fetch.mockResolvedValue(messagesWithOtherBot);
+
+      const result = await service.findExistingVerificationMessage(mockChannel as any);
+
+      expect(result).toBeNull();
+    });
+
+    it('should handle messages without embeds', async () => {
+      const messageWithoutEmbeds = {
+        ...mockMessage,
+        embeds: []
+      };
+      const messagesWithoutEmbeds = new Map([
+        ['no-embed-message', messageWithoutEmbeds]
+      ]);
+      mockChannel.messages.fetch.mockResolvedValue(messagesWithoutEmbeds);
+
+      const result = await service.findExistingVerificationMessage(mockChannel as any);
+
+      expect(result).toBeNull();
+    });
+
+    it('should handle messages with wrong embed title', async () => {
+      const messageWithWrongTitle = {
+        ...mockMessage,
+        embeds: [{ title: 'Wrong Title' }]
+      };
+      const messagesWithWrongTitle = new Map([
+        ['wrong-title-message', messageWithWrongTitle]
+      ]);
+      mockChannel.messages.fetch.mockResolvedValue(messagesWithWrongTitle);
+
+      const result = await service.findExistingVerificationMessage(mockChannel as any);
+
+      expect(result).toBeNull();
+    });
+
+    it('should handle fetch errors gracefully', async () => {
+      mockChannel.messages.fetch.mockRejectedValue(new Error('Fetch failed'));
+
+      const result = await service.findExistingVerificationMessage(mockChannel as any);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('createVerificationMessage', () => {
+    it('should create verification message successfully', async () => {
+      const sentMessage = { id: 'new-message-id' };
+      mockChannel.send.mockResolvedValue(sentMessage);
+
+      const result = await service.createVerificationMessage(mockChannel as any);
+
+      expect(result).toBe('new-message-id');
+      expect(mockChannel.send).toHaveBeenCalledWith({
+        embeds: expect.arrayContaining([
+          expect.objectContaining({
+            data: expect.objectContaining({
+              title: 'Wallet Verification'
+            })
+          })
+        ]),
+        components: expect.arrayContaining([
+          expect.objectContaining({
+            components: expect.arrayContaining([
+              expect.objectContaining({
+                data: expect.objectContaining({
+                  label: 'Verify Now',
+                  custom_id: 'requestVerification'
+                })
+              })
+            ])
+          })
+        ])
+      });
+    });
+
+    it('should handle send errors', async () => {
+      mockChannel.send.mockRejectedValue(new Error('Send failed'));
+
+      await expect(service.createVerificationMessage(mockChannel as any)).rejects.toThrow('Send failed');
+    });
+  });
+});

--- a/backend/test/discord-verification.service.spec.ts
+++ b/backend/test/discord-verification.service.spec.ts
@@ -1,0 +1,223 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DiscordVerificationService } from '../src/services/discord-verification.service';
+import { DbService } from '../src/services/db.service';
+import { NonceService } from '../src/services/nonce.service';
+import { Logger } from '@nestjs/common';
+import { MessageFlags } from 'discord.js';
+
+// Mock Logger methods to suppress error output during tests
+const loggerSpy = jest.spyOn(Logger, 'error').mockImplementation(() => {});
+const loggerDebugSpy = jest.spyOn(Logger, 'debug').mockImplementation(() => {});
+
+const mockDbService = {
+  getServerRole: jest.fn(),
+  findRuleByMessageId: jest.fn(),
+  addServerToUser: jest.fn(),
+};
+
+const mockNonceService = {
+  createNonce: jest.fn(),
+};
+
+const mockClient = {
+  guilds: {
+    cache: new Map([
+      ['guild-id', {
+        id: 'guild-id',
+        name: 'Test Guild',
+        members: {
+          fetch: jest.fn().mockResolvedValue({
+            roles: {
+              add: jest.fn(),
+            },
+          }),
+        },
+        roles: {
+          cache: {
+            get: jest.fn().mockReturnValue({ id: 'role-id', name: 'Test Role' }),
+            map: jest.fn().mockReturnValue([{ id: 'role-id', name: 'Test Role' }])
+          }
+        }
+      }]
+    ])
+  },
+  get: jest.fn().mockImplementation((id) => {
+    return mockClient.guilds.cache.get(id);
+  })
+};
+
+const mockInteraction = {
+  guild: { 
+    id: 'guild-id', 
+    name: 'Test Guild', 
+    iconURL: jest.fn().mockReturnValue('https://example.com/icon.png'),
+    roles: { cache: new Map([['role-id', { id: 'role-id', name: 'Test Role' }]]) } 
+  },
+  channel: { id: 'channel-id' },
+  message: { id: 'message-id' },
+  user: { id: 'user-id', tag: 'testuser#1234', avatarURL: () => 'avatar-url' },
+  deferReply: jest.fn(),
+  editReply: jest.fn(),
+  reply: jest.fn(),
+  isRepliable: jest.fn().mockReturnValue(true),
+  deferred: true,
+};
+
+describe('DiscordVerificationService', () => {
+  let service: DiscordVerificationService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DiscordVerificationService,
+        { provide: DbService, useValue: mockDbService },
+        { provide: NonceService, useValue: mockNonceService },
+      ],
+    }).compile();
+
+    service = module.get<DiscordVerificationService>(DiscordVerificationService);
+    service.initialize(mockClient as any);
+    jest.clearAllMocks();
+    loggerSpy.mockClear();
+    loggerDebugSpy.mockClear();
+  });
+
+  afterAll(() => {
+    loggerSpy.mockRestore();
+    loggerDebugSpy.mockRestore();
+  });
+
+  describe('requestVerification', () => {
+    it('should create verification request successfully', async () => {
+      mockDbService.getServerRole.mockResolvedValue('role-id');
+      mockNonceService.createNonce.mockResolvedValue('test-nonce');
+
+      await service.requestVerification(mockInteraction as any);
+
+      expect(mockInteraction.deferReply).toHaveBeenCalledWith({ flags: MessageFlags.Ephemeral });
+      expect(mockNonceService.createNonce).toHaveBeenCalledWith(
+        'user-id',
+        'message-id',
+        'channel-id'
+      );
+      expect(mockInteraction.editReply).toHaveBeenCalledWith({
+        embeds: expect.arrayContaining([
+          expect.objectContaining({
+            data: expect.objectContaining({
+              title: 'Wallet Verification'
+            })
+          })
+        ]),
+        components: expect.any(Array)
+      });
+    });
+
+    it('should handle error when role not found', async () => {
+      mockDbService.getServerRole.mockResolvedValue(null);
+      mockDbService.findRuleByMessageId.mockResolvedValue(null);
+
+      await service.requestVerification(mockInteraction as any);
+
+      expect(mockInteraction.editReply).toHaveBeenCalledWith({
+        content: 'Error: Verification role not found for this message.'
+      });
+    });
+  });
+
+  describe('addUserRole', () => {
+    it('should add role to user successfully', async () => {
+      const nonce = 'test-nonce';
+      service.tempMessages[nonce] = mockInteraction as any;
+
+      await service.addUserRole('user-id', 'role-id', 'guild-id', 'wallet-address', nonce);
+
+      expect(mockDbService.addServerToUser).toHaveBeenCalledWith(
+        'user-id',
+        'guild-id',
+        'Test Role',
+        'wallet-address'
+      );
+      expect(mockInteraction.editReply).toHaveBeenCalledWith({
+        embeds: expect.arrayContaining([
+          expect.objectContaining({
+            data: expect.objectContaining({
+              title: 'Verification Successful'
+            })
+          })
+        ])
+      });
+      expect(service.tempMessages[nonce]).toBeUndefined();
+    });
+
+    it('should handle error when guild not found', async () => {
+      const nonce = 'test-nonce';
+      service.tempMessages[nonce] = mockInteraction as any;
+
+      await expect(
+        service.addUserRole('user-id', 'role-id', 'invalid-guild', 'wallet-address', nonce)
+      ).rejects.toThrow('Guild not found');
+    });
+
+    it('should handle error when no stored interaction', async () => {
+      await expect(
+        service.addUserRole('user-id', 'role-id', 'guild-id', 'wallet-address', 'invalid-nonce')
+      ).rejects.toThrow('No stored interaction found for this nonce');
+    });
+  });
+
+  describe('throwError', () => {
+    it('should send error message to user', async () => {
+      const nonce = 'test-nonce';
+      service.tempMessages[nonce] = mockInteraction as any;
+
+      await service.throwError(nonce, 'Test error message');
+
+      expect(mockInteraction.editReply).toHaveBeenCalledWith({
+        embeds: expect.arrayContaining([
+          expect.objectContaining({
+            data: expect.objectContaining({
+              title: 'Verification Failed',
+              description: 'Test error message'
+            })
+          })
+        ])
+      });
+      expect(service.tempMessages[nonce]).toBeUndefined();
+    });
+
+    it('should handle missing stored interaction gracefully', async () => {
+      // Should not throw error
+      await service.throwError('invalid-nonce', 'Test error');
+    });
+  });
+
+  describe('getVerificationRoleId', () => {
+    it('should return legacy role ID when available', async () => {
+      mockDbService.getServerRole.mockResolvedValue('legacy-role-id');
+
+      const result = await service.getVerificationRoleId('guild-id', 'channel-id', 'message-id');
+
+      expect(result).toBe('legacy-role-id');
+      expect(mockDbService.getServerRole).toHaveBeenCalledWith('guild-id');
+    });
+
+    it('should return new rule role ID when legacy not available', async () => {
+      mockDbService.getServerRole.mockResolvedValue(null);
+      mockDbService.findRuleByMessageId.mockResolvedValue({ role_id: 'new-role-id' });
+
+      const result = await service.getVerificationRoleId('guild-id', 'channel-id', 'message-id');
+
+      expect(result).toBe('new-role-id');
+      expect(mockDbService.findRuleByMessageId).toHaveBeenCalledWith('guild-id', 'channel-id', 'message-id');
+    });
+
+    it('should return null when no role found', async () => {
+      mockDbService.getServerRole.mockResolvedValue(null);
+      mockDbService.findRuleByMessageId.mockResolvedValue(null);
+
+      const result = await service.getVerificationRoleId('guild-id', 'channel-id', 'message-id');
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/backend/test/nonce.service.spec.ts
+++ b/backend/test/nonce.service.spec.ts
@@ -30,7 +30,7 @@ describe('NonceService', () => {
   });
 
   it('validates a correct nonce', async () => {
-    mockCache.get.mockResolvedValue('abc123');
+    mockCache.get.mockResolvedValue({ nonce: 'abc123', messageId: 'msg1', channelId: 'ch1' });
     const result = await service.validateNonce('user1', 'abc123');
     expect(result).toBe(true);
   });

--- a/backend/test/verify.service.spec.ts
+++ b/backend/test/verify.service.spec.ts
@@ -3,16 +3,28 @@ import { VerifyService } from '../src/services/verify.service';
 import { WalletService } from '../src/services/wallet.service';
 import { NonceService } from '../src/services/nonce.service';
 import { DiscordService } from '../src/services/discord.service';
+import { DiscordVerificationService } from '../src/services/discord-verification.service';
 import { DataService } from '../src/services/data.service';
 import { DbService } from '../src/services/db.service';
 
 const mockWalletService = { verifySignature: jest.fn() };
-const mockNonceService = { invalidateNonce: jest.fn() };
+const mockNonceService = { 
+  invalidateNonce: jest.fn(),
+  getNonceData: jest.fn().mockResolvedValue({ messageId: 'msg-id', channelId: 'ch-id' })
+};
 const mockDiscordService = {
   addUserRole: jest.fn(),
   throwError: jest.fn()
 };
-const mockDataService = { getDetailedAssets: jest.fn() };
+const mockDiscordVerificationService = {
+  addUserRole: jest.fn(),
+  throwError: jest.fn(),
+  getVerificationRoleId: jest.fn().mockResolvedValue('role-id')
+};
+const mockDataService = { 
+  getDetailedAssets: jest.fn(),
+  checkAssetOwnership: jest.fn().mockResolvedValue(1)
+};
 const mockDbService = {
   getServerRole: jest.fn(),
   logUserRole: jest.fn(),
@@ -29,6 +41,7 @@ describe('VerifyService', () => {
         { provide: WalletService, useValue: mockWalletService },
         { provide: NonceService, useValue: mockNonceService },
         { provide: DiscordService, useValue: mockDiscordService },
+        { provide: DiscordVerificationService, useValue: mockDiscordVerificationService },
         { provide: DataService, useValue: mockDataService },
         { provide: DbService, useValue: mockDbService },
       ],
@@ -38,17 +51,21 @@ describe('VerifyService', () => {
   });
 
   it('handles legacy path', async () => {
+    // Mock empty nonce data to trigger legacy path
+    mockNonceService.getNonceData.mockResolvedValue({ messageId: null, channelId: null });
     mockWalletService.verifySignature.mockResolvedValue('0xabc');
     mockDbService.getServerRole.mockResolvedValue('123');
     const payload = { userId: 'u', discordId: 'g', role: 'legacy', nonce: 'n' };
     await service.verifySignatureFlow(payload as any, 'sig');
     expect(mockWalletService.verifySignature).toHaveBeenCalled();
     expect(mockDbService.getServerRole).toHaveBeenCalledWith('g');
-    expect(mockDiscordService.addUserRole).toHaveBeenCalled();
+    expect(mockDiscordVerificationService.addUserRole).toHaveBeenCalled();
     expect(mockDbService.logUserRole).toHaveBeenCalled();
   });
 
   it('handles multi-rule path', async () => {
+    // Mock empty nonce data to trigger multi-rule path
+    mockNonceService.getNonceData.mockResolvedValue({ messageId: null, channelId: null });
     mockWalletService.verifySignature.mockResolvedValue('0xabc');
     mockDbService.getRoleMappings.mockResolvedValue([
       { id: 1, slug: null, channel_id: null, attribute_key: null, attribute_value: null, min_items: null, role_id: 'r1' },
@@ -58,16 +75,18 @@ describe('VerifyService', () => {
     const payload = { userId: 'u', discordId: 'g', nonce: 'n' };
     await service.verifySignatureFlow(payload as any, 'sig');
     expect(mockDbService.getRoleMappings).toHaveBeenCalled();
-    expect(mockDiscordService.addUserRole).toHaveBeenCalledTimes(2);
+    expect(mockDiscordVerificationService.addUserRole).toHaveBeenCalledTimes(2);
     expect(mockDbService.logUserRole).toHaveBeenCalledTimes(2);
   });
 
   it('throws error if no match', async () => {
+    // Mock empty nonce data to trigger multi-rule path, but no matching assets
+    mockNonceService.getNonceData.mockResolvedValue({ messageId: null, channelId: null });
     mockWalletService.verifySignature.mockResolvedValue('0xabc');
     mockDbService.getRoleMappings.mockResolvedValue([]);
     mockDataService.getDetailedAssets.mockResolvedValue([]);
     const payload = { userId: 'u', discordId: 'g', nonce: 'n' };
     await expect(service.verifySignatureFlow(payload as any, 'sig')).rejects.toThrow('No matching assets');
-    expect(mockDiscordService.throwError).toHaveBeenCalled();
+    expect(mockDiscordVerificationService.throwError).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
This pull request introduces significant enhancements to the Discord-related services in the backend, including new functionality for managing verification rules, handling commands, and improving user verification workflows. The most important changes include adding new services (`DiscordCommandsService`, `DiscordMessageService`, and `DiscordVerificationService`), extending the `VerifyService` to integrate these new services, and updating the `app.module.ts` to register the new services.

### New Service Implementations:

#### DiscordCommandsService
* Added `DiscordCommandsService` to handle Discord commands for managing verification rules, including adding, removing, listing, and migrating legacy rules. It interacts with the database and other services to ensure smooth rule management.

#### DiscordMessageService
* Added `DiscordMessageService` to manage Discord messages, including creating and finding Wallet Verification messages in channels. This service ensures proper handling of verification-related messages.

#### DiscordVerificationService
* Added `DiscordVerificationService` to handle user verification workflows, including generating verification links, adding roles to users, and managing temporary interactions. It supports both legacy and new verification rules.

### Updates to Existing Code:

#### Service Integration
* Updated `VerifyService` to include `DiscordVerificationService` for handling user verification processes in Discord. [[1]](diffhunk://#diff-ed7d5c499629907923dbd53d567dbcbc43e6d89b25bf26678c802e8d0228c265R5) [[2]](diffhunk://#diff-ed7d5c499629907923dbd53d567dbcbc43e6d89b25bf26678c802e8d0228c265R17)

#### App Module Enhancements
* Registered the new services (`DiscordCommandsService`, `DiscordMessageService`, and `DiscordVerificationService`) in `app.module.ts` to make them available throughout the application. [[1]](diffhunk://#diff-0c2985c7b189bc65e8ded71e24c833e2d788288beaba00cad243a42ce5c625a2R9-R11) [[2]](diffhunk://#diff-0c2985c7b189bc65e8ded71e24c833e2d788288beaba00cad243a42ce5c625a2R27-R29)