### PR TITLE
feat(v2): Add recovery command for orphaned verification rules in Dis…

### DIFF
--- a/RECOVERY_COMMAND.md
+++ b/RECOVERY_COMMAND.md
@@ -1,0 +1,77 @@
+# Verification Recovery Command
+
+## Overview
+The `/setup recover-verification` command provides a robust solution for handling cases where Discord verification messages are accidentally deleted from channels that have existing verification rules.
+
+## Problem It Solves
+When a verification message with the "Verify Now" button is deleted from a Discord channel, existing rules that reference that message become "orphaned" - they point to a message that no longer exists. This breaks the verification flow for users and can cause significant operational issues.
+
+## How It Works
+
+### Command Usage
+```
+/setup recover-verification channel:#your-channel
+```
+
+### Recovery Process
+1. **Detects Orphaned Rules**: Scans all verification rules for the specified channel and identifies those pointing to non-existent messages
+2. **Creates New Verification Message**: Generates a new "Wallet Verification" message with "Verify Now" button in the channel
+3. **Updates Rule References**: Updates all orphaned rules to point to the new message
+4. **Provides Admin Feedback**: Shows detailed results including:
+   - New message ID created
+   - Number of rules updated
+   - Affected roles
+
+### Safety Features
+- **Non-Destructive**: Only updates rules that reference deleted messages
+- **Validation**: Verifies message existence before considering rules "orphaned"
+- **Error Handling**: Graceful failure handling with detailed error messages
+- **Admin-Only**: Requires appropriate permissions to execute
+
+### Example Output
+When orphaned rules are found and recovered:
+```
+✅ Verification Recovery Complete
+
+New Message Created: Message ID: 1234567890
+Rules Updated: 3/3 rules updated  
+Roles Affected: @Verified, @Premium, @Holder
+```
+
+When no recovery is needed:
+```
+ℹ️ No orphaned verification rules found for this channel. 
+All existing verification messages appear to be intact.
+```
+
+## Technical Implementation
+
+### New Database Method
+- `getRulesByChannel(guildId, channelId)`: Retrieves all rules for a specific channel
+
+### Service Integration  
+- **DiscordCommandsService**: Handles the recovery command logic
+- **DiscordMessageService**: Creates new verification messages and validates existing ones
+- **DbService**: Updates rule references to new message IDs
+
+### Error Scenarios Handled
+- Channel not found or invalid type
+- Database connection issues
+- Discord API failures
+- Partial update failures (continues with remaining rules)
+
+## Benefits
+- **Operational Continuity**: Restores verification functionality quickly
+- **Data Integrity**: Preserves existing rule configurations
+- **Administrative Visibility**: Clear feedback on what was recovered
+- **Minimal Downtime**: Fast recovery process
+- **User Experience**: Seamless transition for end users
+
+## Use Cases
+- Accidental message deletion by moderators
+- Channel cleanup that removes verification messages
+- Message corruption or Discord API issues
+- Server migration scenarios
+- Emergency recovery situations
+
+This command ensures that verification setups remain resilient and can be quickly restored without manual reconfiguration of rules.

--- a/backend/src/services/db.service.ts
+++ b/backend/src/services/db.service.ts
@@ -270,6 +270,19 @@ export class DbService {
     if (error) throw error;
     return data && data.length > 0 ? data[0] as VerifierRole : null;
   }
+
+  /**
+   * Gets all rules for a specific channel in a guild.
+   */
+  async getRulesByChannel(guildId: string, channelId: string): Promise<VerifierRole[]> {
+    const { data, error } = await supabase
+      .from('verifier_rules')
+      .select('*')
+      .eq('server_id', guildId)
+      .eq('channel_id', channelId);
+    if (error) throw error;
+    return data || [];
+  }
 }
 
 // create table

--- a/backend/src/services/discord.service.ts
+++ b/backend/src/services/discord.service.ts
@@ -102,6 +102,8 @@ export class DiscordService {
         await this.discordCommandsSvc.handleRemoveLegacyRule(interaction);
       } else if (sub === 'migrate-legacy-rule') {
         await this.discordCommandsSvc.handleMigrateLegacyRule(interaction);
+      } else if (sub === 'recover-verification') {
+        await this.discordCommandsSvc.handleRecoverVerification(interaction);
       }
     } catch (error) {
       Logger.error('Error in handleSetup:', error);
@@ -174,6 +176,11 @@ export class DiscordService {
           sc.setName('migrate-legacy-rule')
             .setDescription('Migrate a legacy rule to a new rule (prompts for channel)')
             .addChannelOption(option => option.setName('channel').setDescription('Channel for the new rule').setRequired(true))
+        )
+        .addSubcommand(sc =>
+          sc.setName('recover-verification')
+            .setDescription('Recover verification setup for a channel (creates new message, updates orphaned rules)')
+            .addChannelOption(option => option.setName('channel').setDescription('Channel to recover verification for').setRequired(true))
         )
     ];
     Logger.debug('Reloading application /slash commands.', `${commands.length} commands`);


### PR DESCRIPTION
This pull request introduces a new feature to recover Discord verification setups when verification messages are accidentally deleted, along with supporting backend changes and tests. The feature ensures operational continuity by detecting orphaned rules, creating new verification messages, and updating the rules accordingly. Below are the most important changes grouped by theme:

### Feature Implementation:
* Added a new `/setup recover-verification` command to restore deleted verification setups by detecting orphaned rules, creating a new verification message, and updating rule references. Detailed feedback is provided to admins during the process. (`RECOVERY_COMMAND.md`, [RECOVERY_COMMAND.mdR1-R77](diffhunk://#diff-ed301afdb49dc369fc16dc69571583edb0d73b59750267f0e9e8dd584ee5369aR1-R77))
* Implemented the `handleRecoverVerification` method in `DiscordCommandsService` to execute the recovery process, including orphaned rule detection, message creation, and rule updates. (`backend/src/services/discord-commands.service.ts`, [backend/src/services/discord-commands.service.tsR277-R361](diffhunk://#diff-de3f524b0d1dd03b44be9c5aa263c0bc94afdb094969dd1aa20d7f0949cbb02fR277-R361))

### Backend Enhancements:
* Added a `getRulesByChannel` method in `DbService` to retrieve all verification rules for a specific channel. (`backend/src/services/db.service.ts`, [backend/src/services/db.service.tsR273-R285](diffhunk://#diff-784fb6517f0860d32ae94fdc50a5c14548d32c5ba8d7cac2391c6bc4afddaea1R273-R285))
* Integrated the new `recover-verification` subcommand into the Discord service, enabling its execution via slash commands. (`backend/src/services/discord.service.ts`, [[1]](diffhunk://#diff-f4f7eaa546e192917a87a7fe97c6c24e6abd71d7f1a248374cb8050c0952eb71R105-R106) [[2]](diffhunk://#diff-f4f7eaa546e192917a87a7fe97c6c24e6abd71d7f1a248374cb8050c0952eb71R180-R184)

### Testing:
* Extended unit tests for `DiscordCommandsService` to validate the behavior of `handleRecoverVerification`, including scenarios with orphaned rules and intact rules. Mocked dependencies for database and message services. (`backend/test/discord-commands.service.spec.ts`, [[1]](diffhunk://#diff-1e38c18852d1202f824afdd6f1fa57097282f5b7f8bf42cb038301773e95478aR16-R22) [[2]](diffhunk://#diff-1e38c18852d1202f824afdd6f1fa57097282f5b7f8bf42cb038301773e95478aR264-R341)…cord channels