### PR TITLE
feat: add exact duplicate rule check and enhance role handling in cmds

### DIFF
--- a/backend/src/services/db.service.ts
+++ b/backend/src/services/db.service.ts
@@ -427,6 +427,40 @@ export class DbService {
     }
     return data;
   }
+
+  async checkForExactDuplicateRule(
+    serverId: string,
+    channelId: string,
+    slug: string,
+    attributeKey: string,
+    attributeValue: string,
+    minItems: number,
+    roleId: string
+  ): Promise<any> {
+    // Use the same defaults as addRoleMapping for consistent comparison
+    const finalSlug = slug || 'ALL';
+    const finalAttrKey = attributeKey || 'ALL';
+    const finalAttrVal = attributeValue || 'ALL';
+    const finalMinItems = minItems != null ? minItems : 1;
+
+    const { data, error } = await supabase
+      .from('verifier_rules')
+      .select('*')
+      .eq('server_id', serverId)
+      .eq('channel_id', channelId)
+      .eq('slug', finalSlug)
+      .eq('attribute_key', finalAttrKey)
+      .eq('attribute_value', finalAttrVal)
+      .eq('min_items', finalMinItems)
+      .eq('role_id', roleId);
+
+    if (error) {
+      Logger.error('Error checking for exact duplicate rules:', error);
+      throw error;
+    }
+
+    return data && data.length > 0 ? data[0] : null;
+  }
 }
 
 // create table

--- a/backend/test/db.service.spec.ts
+++ b/backend/test/db.service.spec.ts
@@ -368,4 +368,78 @@ describe('DbService - Integration Tests', () => {
       expect(duplicateRule).toBeNull();
     });
   });
+
+  describe('checkForExactDuplicateRule', () => {
+    it('should find exact duplicate rule (same role + same criteria)', async () => {
+      const isHealthy = await testDb.isHealthy();
+      if (!isHealthy) {
+        console.warn('⚠️  Local Supabase not accessible. Skipping test.');
+        return;
+      }
+
+      // First, create a rule
+      await service.addRoleMapping(
+        'test_server_exact_dup',
+        'Test Server',
+        'test_channel_exact_dup',
+        'Test Channel',
+        'test-collection',
+        'test-role-id',
+        'Test Role',
+        'Gold',
+        'rare',
+        1
+      );
+
+      // Try to find exact duplicate
+      const exactDuplicate = await service.checkForExactDuplicateRule(
+        'test_server_exact_dup',
+        'test_channel_exact_dup',
+        'test-collection',
+        'Gold',
+        'rare',
+        1,
+        'test-role-id' // Same role ID - should find the exact match
+      );
+
+      expect(exactDuplicate).toBeDefined();
+      expect(exactDuplicate.server_id).toBe('test_server_exact_dup');
+      expect(exactDuplicate.role_id).toBe('test-role-id');
+    });
+
+    it('should not find duplicate when role is different', async () => {
+      const isHealthy = await testDb.isHealthy();
+      if (!isHealthy) {
+        console.warn('⚠️  Local Supabase not accessible. Skipping test.');
+        return;
+      }
+
+      // First, create a rule
+      await service.addRoleMapping(
+        'test_server_diff_role',
+        'Test Server',
+        'test_channel_diff_role',
+        'Test Channel',
+        'test-collection',
+        'original-role-id',
+        'Original Role',
+        'Gold',
+        'rare',
+        1
+      );
+
+      // Try to find exact duplicate with different role
+      const exactDuplicate = await service.checkForExactDuplicateRule(
+        'test_server_diff_role',
+        'test_channel_diff_role',
+        'test-collection',
+        'Gold',
+        'rare',
+        1,
+        'different-role-id' // Different role ID - should not find match
+      );
+
+      expect(exactDuplicate).toBeNull();
+    });
+  });
 });


### PR DESCRIPTION
This pull request introduces enhancements to role management and rule validation in Discord bot services, focusing on user experience improvements and backend functionality. Key changes include the addition of role autocomplete, duplicate rule detection, and integration tests to ensure reliability.

### Enhancements to Role Management
* [`backend/src/services/discord.service.ts`](diffhunk://#diff-f4f7eaa546e192917a87a7fe97c6c24e6abd71d7f1a248374cb8050c0952eb71R71-R81): Added role autocomplete functionality to assist users in selecting existing roles or creating new ones when adding verification rules. This ensures better usability and prevents errors. [[1]](diffhunk://#diff-f4f7eaa546e192917a87a7fe97c6c24e6abd71d7f1a248374cb8050c0952eb71R71-R81) [[2]](diffhunk://#diff-f4f7eaa546e192917a87a7fe97c6c24e6abd71d7f1a248374cb8050c0952eb71R286-R350)
* [`backend/src/services/discord-commands.service.ts`](diffhunk://#diff-de3f524b0d1dd03b44be9c5aa263c0bc94afdb094969dd1aa20d7f0949cbb02fL43-R156): Updated role handling logic to check for existing roles, ensure bot manageability, and create new roles if necessary. Added detailed error messages for role hierarchy issues.

### Improvements to Rule Validation
* [`backend/src/services/db.service.ts`](diffhunk://#diff-784fb6517f0860d32ae94fdc50a5c14548d32c5ba8d7cac2391c6bc4afddaea1R430-R463): Introduced `checkForExactDuplicateRule` method to detect duplicate verification rules based on exact criteria, improving rule validation consistency.
* [`backend/src/services/discord-commands.service.ts`](diffhunk://#diff-de3f524b0d1dd03b44be9c5aa263c0bc94afdb094969dd1aa20d7f0949cbb02fL43-R156): Integrated exact duplicate rule detection and added user-friendly error messages with actionable suggestions when duplicates are found.

### Integration Tests for Reliability
* [`backend/test/db.service.spec.ts`](diffhunk://#diff-6caf02d79455e48914c7403b84ccb7e289ef4137a44a1d8210d4e4da39801b01R371-R444): Added tests for `checkForExactDuplicateRule` to verify detection of exact duplicates and differentiation when roles differ.
* [`backend/test/discord.service.spec.ts`](diffhunk://#diff-26670035b4f8b097a1030593ef07160b2eceedf4449f5822c9cd912415be152cR151-R238): Added tests for role autocomplete functionality, ensuring correct suggestions and graceful error handling.