### PR TITLE
Add unit tests for DiscordService and improve console error handling in tests

### DIFF
--- a/backend/test/data.service.spec.ts
+++ b/backend/test/data.service.spec.ts
@@ -5,22 +5,54 @@ jest.mock('dotenv', () => ({
   config: jest.fn()
 }));
 
-// Mock Supabase completely before any imports
-const mockSupabaseQuery = {
-  select: jest.fn().mockReturnThis(),
-  or: jest.fn().mockReturnThis(),
-  eq: jest.fn().mockReturnThis(),
-  ilike: jest.fn().mockReturnThis(),
-  in: jest.fn().mockReturnThis(),
-  gte: jest.fn().mockReturnThis()
+// Set up environment variables to prevent the service from throwing
+process.env.DATA_SUPABASE_URL = 'http://localhost:3000';
+process.env.DATA_SUPABASE_ANON_KEY = 'test-key';
+
+// Create a mock that has all query methods and can be awaited as a promise
+const createMockQuery = () => {
+  // Queue of results for sequential calls
+  let resultQueue = [{ data: [], error: null }];
+  let currentIndex = 0;
+  
+  const mockQuery = {
+    select: jest.fn(),
+    or: jest.fn(),
+    eq: jest.fn(),
+    in: jest.fn(),
+    // Make the query awaitable by inheriting from Promise
+    then: jest.fn((onFulfilled, onRejected) => {
+      const result = resultQueue[Math.min(currentIndex, resultQueue.length - 1)];
+      currentIndex++;
+      return Promise.resolve(result).then(onFulfilled, onRejected);
+    }),
+    catch: jest.fn((onRejected) => Promise.resolve().catch(onRejected)),
+    // Helper to set the promise result
+    setResult: (result) => {
+      resultQueue = [result];
+      currentIndex = 0;
+    },
+    // Helper to set multiple results for sequential calls
+    setResults: (results) => {
+      resultQueue = results;
+      currentIndex = 0;
+    },
+    // Reset the call counter
+    resetIndex: () => {
+      currentIndex = 0;
+    }
+  };
+  
+  // Each method returns the same mock object to allow chaining
+  mockQuery.select.mockReturnValue(mockQuery);
+  mockQuery.or.mockReturnValue(mockQuery);
+  mockQuery.eq.mockReturnValue(mockQuery);
+  mockQuery.in.mockReturnValue(mockQuery);
+  
+  return mockQuery;
 };
 
-// Make all query methods return promises that resolve to empty data
-Object.keys(mockSupabaseQuery).forEach(method => {
-  if (method !== 'select') {
-    mockSupabaseQuery[method].mockResolvedValue({ data: [], error: null });
-  }
-});
+let mockSupabaseQuery = createMockQuery();
 
 const mockSupabaseClient = {
   from: jest.fn(() => mockSupabaseQuery)
@@ -30,24 +62,17 @@ jest.mock('@supabase/supabase-js', () => ({
   createClient: jest.fn(() => mockSupabaseClient)
 }));
 
-// Now import the service after mocking
 import { DataService } from '../src/services/data.service';
 
 describe('DataService', () => {
   let service: DataService;
 
   beforeEach(async () => {
-    // Reset all mocks before each test
     jest.clearAllMocks();
     
-    // Setup proper mock implementation
-    mockSupabaseQuery.select.mockReturnValue(mockSupabaseQuery);
-    mockSupabaseQuery.or.mockReturnValue(mockSupabaseQuery);
-    mockSupabaseQuery.eq.mockReturnValue(mockSupabaseQuery);
-    
-    // Set default resolved value
-    mockSupabaseQuery.eq.mockResolvedValue({ data: [], error: null });
-    mockSupabaseQuery.or.mockResolvedValue({ data: [], error: null });
+    // Create a fresh mock query for each test
+    mockSupabaseQuery = createMockQuery();
+    mockSupabaseClient.from.mockReturnValue(mockSupabaseQuery);
     
     const module: TestingModule = await Test.createTestingModule({
       providers: [DataService],
@@ -60,61 +85,343 @@ describe('DataService', () => {
     expect(service).toBeDefined();
   });
 
-  it('should have required methods', () => {
-    expect(typeof service.checkAssetOwnership).toBe('function');
-    expect(typeof service.getOwnedSlugs).toBe('function');
-    expect(typeof service.getDetailedAssets).toBe('function');
-    expect(typeof service.getAllSlugs).toBe('function');
-    expect(typeof service.checkAssetOwnershipWithCriteria).toBe('function');
+  describe('checkAssetOwnership', () => {
+    it('should return a number', async () => {
+      const result = await service.checkAssetOwnership('0x123');
+      expect(typeof result).toBe('number');
+    });
+
+    it('should handle empty data', async () => {
+      mockSupabaseQuery.setResult({ data: [], error: null });
+      const result = await service.checkAssetOwnership('0x123');
+      expect(result).toBe(0);
+    });
+
+    it('should handle non-empty data', async () => {
+      mockSupabaseQuery.setResult({ 
+        data: [{ hashId: '1' }, { hashId: '2' }], 
+        error: null 
+      });
+      const result = await service.checkAssetOwnership('0x123');
+      expect(result).toBe(2);
+    });
+
+    it('should handle database errors', async () => {
+      mockSupabaseQuery.setResult({ 
+        data: null, 
+        error: { message: 'Database error' } 
+      });
+      await expect(service.checkAssetOwnership('0x123')).rejects.toThrow('Database error');
+    });
   });
 
-  it('should handle checkAssetOwnership calls', async () => {
-    const result = await service.checkAssetOwnership('0x123');
-    expect(typeof result).toBe('number');
+  describe('getOwnedSlugs', () => {
+    it('should return an array', async () => {
+      const result = await service.getOwnedSlugs('0x123');
+      expect(Array.isArray(result)).toBe(true);
+    });
+
+    it('should return unique slugs', async () => {
+      mockSupabaseQuery.setResult({ 
+        data: [
+          { slug: 'collection1' },
+          { slug: 'collection2' },
+          { slug: 'collection1' } // duplicate
+        ], 
+        error: null 
+      });
+      const result = await service.getOwnedSlugs('0x123');
+      expect(result).toEqual(['collection1', 'collection2']);
+    });
+
+    it('should handle null data', async () => {
+      mockSupabaseQuery.setResult({ data: null, error: null });
+      const result = await service.getOwnedSlugs('0x123');
+      expect(result).toEqual([]);
+    });
+
+    it('should handle database errors', async () => {
+      mockSupabaseQuery.setResult({ 
+        data: null, 
+        error: { message: 'Query failed' } 
+      });
+      await expect(service.getOwnedSlugs('0x123')).rejects.toThrow('Query failed');
+    });
   });
 
-  it('should handle getOwnedSlugs calls', async () => {
-    const result = await service.getOwnedSlugs('0x123');
-    expect(Array.isArray(result)).toBe(true);
+  describe('getDetailedAssets', () => {
+    it('should return an array', async () => {
+      const result = await service.getDetailedAssets('0x123');
+      expect(Array.isArray(result)).toBe(true);
+    });
+
+    it('should return empty array when no ethscriptions', async () => {
+      mockSupabaseQuery.setResult({ data: [], error: null });
+      const result = await service.getDetailedAssets('0x123');
+      expect(result).toEqual([]);
+    });
+
+    it('should combine ethscriptions with attributes', async () => {
+      // Set up results for two sequential calls
+      mockSupabaseQuery.setResults([
+        // First call for ethscriptions
+        { 
+          data: [{ hashId: '1', slug: 'test', sha: 'sha1' }], 
+          error: null 
+        },
+        // Second call for attributes  
+        { 
+          data: [{ sha: 'sha1', values: { rarity: 'rare' } }], 
+          error: null 
+        }
+      ]);
+      
+      const result = await service.getDetailedAssets('0x123');
+      expect(result).toEqual([{ slug: 'test', attributes: { rarity: 'rare' } }]);
+    });
+
+    it('should handle ethscriptions query errors', async () => {
+      mockSupabaseQuery.setResult({ 
+        data: null, 
+        error: { message: 'Ethscriptions error' } 
+      });
+      await expect(service.getDetailedAssets('0x123'))
+        .rejects.toThrow('Failed to fetch ethscriptions: Ethscriptions error');
+    });
+
+    it('should handle attributes query errors', async () => {
+      // Set up results for two sequential calls
+      mockSupabaseQuery.setResults([
+        // First call succeeds
+        { 
+          data: [{ hashId: '1', slug: 'test', sha: 'sha1' }], 
+          error: null 
+        },
+        // Second call fails
+        { 
+          data: null, 
+          error: { message: 'Attributes error' } 
+        }
+      ]);
+      await expect(service.getDetailedAssets('0x123'))
+        .rejects.toThrow('Failed to fetch attributes: Attributes error');
+    });
+  });
+
+  describe('getAllSlugs', () => {
+    it('should return array with all-collections prefix', async () => {
+      mockSupabaseQuery.setResult({ 
+        data: [{ slug: 'collection1' }], 
+        error: null 
+      });
+      const result = await service.getAllSlugs();
+      expect(result).toEqual(['all-collections', 'collection1']);
+    });
+
+    it('should handle empty collections', async () => {
+      mockSupabaseQuery.setResult({ data: [], error: null });
+      const result = await service.getAllSlugs();
+      expect(result).toEqual(['all-collections']);
+    });
+
+    it('should handle database errors', async () => {
+      mockSupabaseQuery.setResult({ 
+        data: null, 
+        error: { message: 'Collections error' } 
+      });
+      await expect(service.getAllSlugs()).rejects.toThrow('Collections error');
+    });
   });
 
   describe('checkAssetOwnershipWithCriteria', () => {
-    it('should handle "ALL" attribute_key like null/empty', async () => {
-      // Mock the final resolved value for the simple ownership check path
-      const mockQueryChain = { data: [{ hashId: '1' }, { hashId: '2' }], error: null };
-      
-      // Setup chain - the last call in the chain will return the result
-      mockSupabaseQuery.or.mockResolvedValueOnce(mockQueryChain);
-
+    it('should handle basic queries without attributes', async () => {
+      mockSupabaseQuery.setResult({ 
+        data: [{ hashId: '1' }], 
+        error: null 
+      });
       const result = await service.checkAssetOwnershipWithCriteria('0x123', 'ALL', 'ALL', 'ALL', 1);
-      
-      expect(typeof result).toBe('number');
-      expect(result).toBeGreaterThanOrEqual(0);
+      expect(result).toBe(1);
     });
 
-    it('should handle "ALL" attribute_value to match any value for given key', async () => {
-      // Use 'ALL' for slug too to avoid triggering slug filtering logic
-      const mockQueryChain = { data: [], error: null };
-      mockSupabaseQuery.or.mockResolvedValueOnce(mockQueryChain);
-
-      const result = await service.checkAssetOwnershipWithCriteria('0x123', 'ALL', 'ALL', 'ALL', 1);
-      expect(typeof result).toBe('number');
+    it('should return 0 when minimum not met', async () => {
+      mockSupabaseQuery.setResult({ 
+        data: [{ hashId: '1' }], 
+        error: null 
+      });
+      const result = await service.checkAssetOwnershipWithCriteria('0x123', 'ALL', 'ALL', 'ALL', 3);
+      expect(result).toBe(0);
     });
 
-    it('should treat null and "ALL" the same way', async () => {
-      // Mock the query chain for simple ownership check
-      const mockQueryChain = { data: [{ hashId: '1' }], error: null };
-      
-      // Setup chain for both calls
-      mockSupabaseQuery.or.mockResolvedValueOnce(mockQueryChain);
-      mockSupabaseQuery.or.mockResolvedValueOnce(mockQueryChain);
+    it('should handle attribute filtering queries', async () => {
+      mockSupabaseQuery.setResult({ 
+        data: [
+          {
+            hashId: '1',
+            attributes_new: { values: { rarity: 'rare' } }
+          }
+        ], 
+        error: null 
+      });
+      const result = await service.checkAssetOwnershipWithCriteria('0x123', 'ALL', 'rarity', 'rare', 1);
+      expect(result).toBe(1);
+    });
 
-      const resultWithNull = await service.checkAssetOwnershipWithCriteria('0x123', null, null, null, 1);
-      const resultWithAll = await service.checkAssetOwnershipWithCriteria('0x123', 'ALL', 'ALL', 'ALL', 1);
+    it('should handle join query errors', async () => {
+      mockSupabaseQuery.setResult({ 
+        data: null, 
+        error: { message: 'Join error' } 
+      });
+      await expect(service.checkAssetOwnershipWithCriteria('0x123', 'ALL', 'rarity', 'rare', 1))
+        .rejects.toThrow('Failed to query with join: Join error');
+    });
+  });
+
+  describe('checkAssetOwnershipWithCriteria - additional coverage', () => {
+    it('should handle slug filtering for specific collections', async () => {
+      mockSupabaseQuery.setResult({ 
+        data: [{ hashId: '1' }], 
+        error: null 
+      });
+      const result = await service.checkAssetOwnershipWithCriteria('0x123', 'specific-collection', 'ALL', 'ALL', 1);
+      expect(result).toBe(1);
+    });
+
+    it('should return 0 when no items found with join query', async () => {
+      mockSupabaseQuery.setResult({ 
+        data: [], 
+        error: null 
+      });
+      const result = await service.checkAssetOwnershipWithCriteria('0x123', 'ALL', 'rarity', 'rare', 1);
+      expect(result).toBe(0);
+    });
+
+    it('should handle attribute key "ALL" searching across all keys', async () => {
+      mockSupabaseQuery.setResult({ 
+        data: [
+          {
+            hashId: '1',
+            attributes_new: { values: { rarity: 'rare', type: 'legendary' } }
+          }
+        ], 
+        error: null 
+      });
+      const result = await service.checkAssetOwnershipWithCriteria('0x123', 'ALL', 'ALL', 'rare', 1);
+      expect(result).toBe(1);
+    });
+
+    it('should handle case-insensitive attribute key matching', async () => {
+      mockSupabaseQuery.setResult({ 
+        data: [
+          {
+            hashId: '1',
+            attributes_new: { values: { Rarity: 'rare' } }
+          }
+        ], 
+        error: null 
+      });
+      const result = await service.checkAssetOwnershipWithCriteria('0x123', 'ALL', 'rarity', 'rare', 1);
+      expect(result).toBe(1);
+    });
+
+    it('should handle attribute key without specific value (ANY value)', async () => {
+      mockSupabaseQuery.setResult({ 
+        data: [
+          {
+            hashId: '1',
+            attributes_new: { values: { rarity: 'common' } }
+          }
+        ], 
+        error: null 
+      });
+      // Using empty string for attributeValue should match any value for the key
+      const result = await service.checkAssetOwnershipWithCriteria('0x123', 'ALL', 'rarity', '', 1);
+      expect(result).toBe(1);
+    });
+
+    it('should handle missing attributes_new in response data', async () => {
+      mockSupabaseQuery.setResult({ 
+        data: [
+          {
+            hashId: '1',
+            // Missing attributes_new
+          }
+        ], 
+        error: null 
+      });
+      const result = await service.checkAssetOwnershipWithCriteria('0x123', 'ALL', 'rarity', 'rare', 1);
+      expect(result).toBe(0);
+    });
+  });
+
+  describe('getAllSlugs - additional coverage', () => {
+    it('should handle null/undefined data gracefully', async () => {
+      mockSupabaseQuery.setResult({ data: null, error: null });
+      const result = await service.getAllSlugs();
+      expect(result).toEqual(['all-collections']);
+    });
+  });
+
+  describe('getDetailedAssets - additional coverage', () => {
+    it('should handle missing sha values in ethscriptions', async () => {
+      mockSupabaseQuery.setResults([
+        // First call - ethscriptions with some missing sha values
+        { 
+          data: [
+            { hashId: '1', slug: 'test1', sha: 'sha1' },
+            { hashId: '2', slug: 'test2', sha: null },
+            { hashId: '3', slug: 'test3', sha: undefined }
+          ], 
+          error: null 
+        },
+        // Second call - attributes (only for sha1)
+        { 
+          data: [{ sha: 'sha1', values: { rarity: 'rare' } }], 
+          error: null 
+        }
+      ]);
       
-      // Both should use the same code path and return the same type
-      expect(typeof resultWithNull).toBe('number');
-      expect(typeof resultWithAll).toBe('number');
+      const result = await service.getDetailedAssets('0x123');
+      expect(result).toEqual([
+        { slug: 'test1', attributes: { rarity: 'rare' } },
+        { slug: 'test2', attributes: {} },
+        { slug: 'test3', attributes: {} }
+      ]);
+    });
+
+    it('should handle missing or null attributes data', async () => {
+      mockSupabaseQuery.setResults([
+        { 
+          data: [{ hashId: '1', slug: 'test', sha: 'sha1' }], 
+          error: null 
+        },
+        { 
+          data: null, // No attributes found
+          error: null 
+        }
+      ]);
+      
+      const result = await service.getDetailedAssets('0x123');
+      expect(result).toEqual([{ slug: 'test', attributes: {} }]);
+    });
+  });
+
+  describe('error handling coverage', () => {
+    it('should handle basic query errors in checkAssetOwnershipWithCriteria', async () => {
+      mockSupabaseQuery.setResult({ 
+        data: null, 
+        error: { message: 'Basic query error' } 
+      });
+      await expect(service.checkAssetOwnershipWithCriteria('0x123', 'ALL', 'ALL', 'ALL', 1))
+        .rejects.toThrow('Basic query error');
+    });
+
+    it('should handle slug filtering in attribute queries', async () => {
+      mockSupabaseQuery.setResult({ 
+        data: [{ hashId: '1', attributes_new: { values: { rarity: 'rare' } } }], 
+        error: null 
+      });
+      const result = await service.checkAssetOwnershipWithCriteria('0x123', 'specific-collection', 'rarity', 'rare', 1);
+      expect(result).toBe(1);
     });
   });
 });

--- a/backend/test/db.service.unit.spec.ts
+++ b/backend/test/db.service.unit.spec.ts
@@ -1,0 +1,696 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+// Mock dotenv to prevent real config loading
+jest.mock('dotenv', () => ({
+  config: jest.fn()
+}));
+
+// Set up environment variables to prevent the service from throwing
+process.env.DB_SUPABASE_URL = 'http://localhost:3000';
+process.env.DB_SUPABASE_KEY = 'test-key';
+
+// Create a comprehensive mock for Supabase operations
+const createMockQuery = () => {
+  // Queue of results for sequential calls
+  let resultQueue = [{ data: [], error: null }];
+  let currentIndex = 0;
+  
+  const mockQuery = {
+    select: jest.fn(),
+    from: jest.fn(),
+    upsert: jest.fn(),
+    insert: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+    eq: jest.fn(),
+    neq: jest.fn(),
+    not: jest.fn(),
+    limit: jest.fn(),
+    single: jest.fn(),
+    // Make the query awaitable by inheriting from Promise
+    then: jest.fn((onFulfilled, onRejected) => {
+      const result = resultQueue[Math.min(currentIndex, resultQueue.length - 1)];
+      currentIndex++;
+      return Promise.resolve(result).then(onFulfilled, onRejected);
+    }),
+    catch: jest.fn((onRejected) => Promise.resolve().catch(onRejected)),
+    // Helper to set the promise result
+    setResult: (result) => {
+      resultQueue = [result];
+      currentIndex = 0;
+    },
+    // Helper to set multiple results for sequential calls
+    setResults: (results) => {
+      resultQueue = results;
+      currentIndex = 0;
+    },
+    // Reset the call counter
+    resetIndex: () => {
+      currentIndex = 0;
+    }
+  };
+  
+  // Each method returns the same mock object to allow chaining
+  mockQuery.select.mockReturnValue(mockQuery);
+  mockQuery.from.mockReturnValue(mockQuery);
+  mockQuery.upsert.mockReturnValue(mockQuery);
+  mockQuery.insert.mockReturnValue(mockQuery);
+  mockQuery.update.mockReturnValue(mockQuery);
+  mockQuery.delete.mockReturnValue(mockQuery);
+  mockQuery.eq.mockReturnValue(mockQuery);
+  mockQuery.neq.mockReturnValue(mockQuery);
+  mockQuery.not.mockReturnValue(mockQuery);
+  mockQuery.limit.mockReturnValue(mockQuery);
+  mockQuery.single.mockReturnValue(mockQuery);
+  
+  return mockQuery;
+};
+
+let mockSupabaseQuery = createMockQuery();
+
+const mockSupabaseClient = {
+  from: jest.fn(() => mockSupabaseQuery)
+};
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: jest.fn(() => mockSupabaseClient)
+}));
+
+import { DbService } from '../src/services/db.service';
+
+describe('DbService - Unit Tests', () => {
+  let service: DbService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    
+    // Create a fresh mock query for each test
+    mockSupabaseQuery = createMockQuery();
+    mockSupabaseClient.from.mockReturnValue(mockSupabaseQuery);
+    
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [DbService],
+    }).compile();
+
+    service = module.get<DbService>(DbService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('addUpdateServer', () => {
+    it('should create/update a server successfully', async () => {
+      mockSupabaseQuery.setResult({ data: [{ id: 'server1' }], error: null });
+      
+      const result = await service.addUpdateServer('server1', 'Test Server', 'role1');
+      
+      expect(mockSupabaseClient.from).toHaveBeenCalledWith('verifier_servers');
+      expect(mockSupabaseQuery.upsert).toHaveBeenCalledWith({
+        id: 'server1',
+        name: 'Test Server',
+        role_id: 'role1'
+      });
+      expect(result).toEqual([{ id: 'server1' }]);
+    });
+
+    it('should handle database errors', async () => {
+      mockSupabaseQuery.setResult({ data: null, error: { message: 'Database error' } });
+      
+      await expect(service.addUpdateServer('server1', 'Test Server', 'role1'))
+        .rejects.toEqual({ message: 'Database error' });
+    });
+  });
+
+  describe('getUserServers', () => {
+    it('should return user server data', async () => {
+      const mockUserData = { user_id: 'user1', servers: { server1: 'role1' } };
+      mockSupabaseQuery.setResult({ data: [mockUserData], error: null });
+      
+      const result = await service.getUserServers('user1');
+      
+      expect(mockSupabaseClient.from).toHaveBeenCalledWith('verifier_users');
+      expect(mockSupabaseQuery.select).toHaveBeenCalledWith('*');
+      expect(mockSupabaseQuery.eq).toHaveBeenCalledWith('user_id', 'user1');
+      expect(result).toEqual(mockUserData);
+    });
+
+    it('should handle database errors', async () => {
+      mockSupabaseQuery.setResult({ data: null, error: { message: 'User fetch error' } });
+      
+      await expect(service.getUserServers('user1'))
+        .rejects.toEqual({ message: 'User fetch error' });
+    });
+  });
+
+  describe('addServerToUser', () => {
+    it('should add server to user with existing servers', async () => {
+      // Mock the fetch call first
+      const existingData = { servers: { server1: 'role1' } };
+      mockSupabaseQuery.setResults([
+        { data: [existingData], error: null },
+        { data: [{ user_id: 'user1' }], error: null }
+      ]);
+      
+      const result = await service.addServerToUser('user1', 'server2', 'role2', '0xABC123');
+      
+      expect(mockSupabaseQuery.upsert).toHaveBeenCalledWith({
+        user_id: 'user1',
+        address: '0xabc123',
+        servers: { server1: 'role1', server2: 'role2' }
+      }, {
+        onConflict: 'user_id'
+      });
+      expect(result).toEqual([{ user_id: 'user1' }]);
+    });
+
+    it('should handle new user with no existing servers', async () => {
+      mockSupabaseQuery.setResults([
+        { data: [{}], error: null },
+        { data: [{ user_id: 'user1' }], error: null }
+      ]);
+      
+      const result = await service.addServerToUser('user1', 'server1', 'role1', '0xABC123');
+      
+      expect(mockSupabaseQuery.upsert).toHaveBeenCalledWith({
+        user_id: 'user1',
+        address: '0xabc123',
+        servers: { server1: 'role1' }
+      }, {
+        onConflict: 'user_id'
+      });
+    });
+
+    it('should handle fetch errors', async () => {
+      mockSupabaseQuery.setResult({ data: null, error: { message: 'Fetch error' } });
+      
+      await expect(service.addServerToUser('user1', 'server1', 'role1', '0xABC123'))
+        .rejects.toEqual({ message: 'Fetch error' });
+    });
+  });
+
+  describe('getServerRole', () => {
+    it('should return role_id for server', async () => {
+      mockSupabaseQuery.setResult({ 
+        data: [{ role_id: 'role123' }], 
+        error: null 
+      });
+      
+      const result = await service.getServerRole('server1');
+      
+      expect(mockSupabaseClient.from).toHaveBeenCalledWith('verifier_servers');
+      expect(mockSupabaseQuery.select).toHaveBeenCalledWith('role_id');
+      expect(mockSupabaseQuery.eq).toHaveBeenCalledWith('id', 'server1');
+      expect(result).toBe('role123');
+    });
+
+    it('should return undefined for non-existent server', async () => {
+      mockSupabaseQuery.setResult({ data: [], error: null });
+      
+      const result = await service.getServerRole('nonexistent');
+      
+      expect(result).toBeUndefined();
+    });
+
+    it('should handle database errors', async () => {
+      mockSupabaseQuery.setResult({ data: null, error: { message: 'Server error' } });
+      
+      await expect(service.getServerRole('server1'))
+        .rejects.toEqual({ message: 'Server error' });
+    });
+  });
+
+  describe('checkForDuplicateRule', () => {
+    it('should find duplicate rule with different role', async () => {
+      const mockRule = {
+        id: 1,
+        server_id: 'server1',
+        channel_id: 'channel1',
+        slug: 'collection1',
+        role_id: 'other-role'
+      };
+      mockSupabaseQuery.setResult({ data: [mockRule], error: null });
+      
+      const result = await service.checkForDuplicateRule(
+        'server1', 'channel1', 'collection1', 'trait', 'value', 1, 'current-role'
+      );
+      
+      expect(result).toEqual(mockRule);
+      expect(mockSupabaseQuery.neq).toHaveBeenCalledWith('role_id', 'current-role');
+    });
+
+    it('should return null when no duplicate found', async () => {
+      mockSupabaseQuery.setResult({ data: [], error: null });
+      
+      const result = await service.checkForDuplicateRule(
+        'server1', 'channel1', 'collection1', 'trait', 'value', 1
+      );
+      
+      expect(result).toBeNull();
+    });
+
+    it('should handle default values properly', async () => {
+      mockSupabaseQuery.setResult({ data: [], error: null });
+      
+      await service.checkForDuplicateRule('server1', 'channel1', '', '', '', null);
+      
+      expect(mockSupabaseQuery.eq).toHaveBeenCalledWith('slug', 'ALL');
+      expect(mockSupabaseQuery.eq).toHaveBeenCalledWith('attribute_key', 'ALL');
+      expect(mockSupabaseQuery.eq).toHaveBeenCalledWith('attribute_value', 'ALL');
+      expect(mockSupabaseQuery.eq).toHaveBeenCalledWith('min_items', 1);
+    });
+
+    it('should handle database errors', async () => {
+      mockSupabaseQuery.setResult({ 
+        data: null, 
+        error: { message: 'Database query error' } 
+      });
+      
+      await expect(service.checkForDuplicateRule(
+        'server1', 'channel1', 'collection1', 'trait', 'value', 1
+      )).rejects.toEqual({ message: 'Database query error' });
+    });
+  });
+
+  describe('addRoleMapping', () => {
+    it('should add role mapping with all parameters', async () => {
+      const mockResult = {
+        id: 1,
+        server_id: 'server1',
+        slug: 'collection1',
+        min_items: 2
+      };
+      mockSupabaseQuery.setResult({ data: mockResult, error: null });
+      
+      const result = await service.addRoleMapping(
+        'server1', 'Server Name', 'channel1', 'Channel Name',
+        'collection1', 'role1', 'Role Name', 'trait', 'value', 2
+      );
+      
+      expect(mockSupabaseQuery.insert).toHaveBeenCalledWith({
+        server_id: 'server1',
+        server_name: 'Server Name',
+        channel_id: 'channel1',
+        channel_name: 'Channel Name',
+        slug: 'collection1',
+        role_id: 'role1',
+        role_name: 'Role Name',
+        attribute_key: 'trait',
+        attribute_value: 'value',
+        min_items: 2
+      });
+      expect(result).toEqual(mockResult);
+    });
+
+    it('should use default values for empty parameters', async () => {
+      mockSupabaseQuery.setResult({ data: {}, error: null });
+      
+      await service.addRoleMapping(
+        'server1', 'Server Name', 'channel1', 'Channel Name',
+        '', 'role1', 'Role Name', '', '', null
+      );
+      
+      expect(mockSupabaseQuery.insert).toHaveBeenCalledWith({
+        server_id: 'server1',
+        server_name: 'Server Name',
+        channel_id: 'channel1',
+        channel_name: 'Channel Name',
+        slug: 'ALL',
+        role_id: 'role1',
+        role_name: 'Role Name',
+        attribute_key: 'ALL',
+        attribute_value: 'ALL',
+        min_items: 1
+      });
+    });
+  });
+
+  describe('getRoleMappings', () => {
+    it('should get all role mappings for server', async () => {
+      const mockRules = [
+        { id: 1, server_id: 'server1', channel_id: 'channel1' },
+        { id: 2, server_id: 'server1', channel_id: 'channel2' }
+      ];
+      mockSupabaseQuery.setResult({ data: mockRules, error: null });
+      
+      const result = await service.getRoleMappings('server1');
+      
+      expect(mockSupabaseQuery.eq).toHaveBeenCalledWith('server_id', 'server1');
+      expect(result).toEqual(mockRules);
+    });
+
+    it('should filter by channel when provided', async () => {
+      const mockRules = [{ id: 1, server_id: 'server1', channel_id: 'channel1' }];
+      mockSupabaseQuery.setResult({ data: mockRules, error: null });
+      
+      const result = await service.getRoleMappings('server1', 'channel1');
+      
+      expect(mockSupabaseQuery.eq).toHaveBeenCalledWith('server_id', 'server1');
+      expect(mockSupabaseQuery.eq).toHaveBeenCalledWith('channel_id', 'channel1');
+      expect(result).toEqual(mockRules);
+    });
+  });
+
+  describe('deleteRoleMapping', () => {
+    it('should delete rule that belongs to server', async () => {
+      mockSupabaseQuery.setResults([
+        { data: [{ server_id: 'server1' }], error: null },
+        { data: null, error: null }
+      ]);
+      
+      await service.deleteRoleMapping('rule1', 'server1');
+      
+      expect(mockSupabaseQuery.delete).toHaveBeenCalled();
+      expect(mockSupabaseQuery.eq).toHaveBeenCalledWith('id', 'rule1');
+      expect(mockSupabaseQuery.eq).toHaveBeenCalledWith('server_id', 'server1');
+    });
+
+    it('should throw error if rule does not belong to server', async () => {
+      mockSupabaseQuery.setResult({ data: [{ server_id: 'other-server' }], error: null });
+      
+      await expect(service.deleteRoleMapping('rule1', 'server1'))
+        .rejects.toThrow('Rule does not belong to this server');
+    });
+
+    it('should throw error if rule does not exist', async () => {
+      mockSupabaseQuery.setResult({ data: [], error: null });
+      
+      await expect(service.deleteRoleMapping('rule1', 'server1'))
+        .rejects.toThrow('Rule does not belong to this server');
+    });
+  });
+
+  describe('logUserRole', () => {
+    it('should log user role assignment with all details', async () => {
+      mockSupabaseQuery.setResult({ data: null, error: null });
+      
+      await service.logUserRole(
+        'user1', 'server1', 'role1', '0xABC123',
+        'TestUser', 'TestServer', 'TestRole'
+      );
+      
+      expect(mockSupabaseClient.from).toHaveBeenCalledWith('verifier_user_roles');
+      expect(mockSupabaseQuery.insert).toHaveBeenCalledWith({
+        user_id: 'user1',
+        server_id: 'server1',
+        role_id: 'role1',
+        address: '0xabc123',
+        assigned_at: expect.any(String),
+        user_name: 'TestUser',
+        server_name: 'TestServer',
+        role_name: 'TestRole'
+      });
+    });
+
+    it('should handle null optional parameters', async () => {
+      mockSupabaseQuery.setResult({ data: null, error: null });
+      
+      await service.logUserRole('user1', 'server1', 'role1', '0xABC123');
+      
+      expect(mockSupabaseQuery.insert).toHaveBeenCalledWith({
+        user_id: 'user1',
+        server_id: 'server1',
+        role_id: 'role1',
+        address: '0xabc123',
+        assigned_at: expect.any(String),
+        user_name: null,
+        server_name: null,
+        role_name: null
+      });
+    });
+
+    it('should handle database errors', async () => {
+      mockSupabaseQuery.setResult({ data: null, error: { message: 'Log error' } });
+      
+      await expect(service.logUserRole('user1', 'server1', 'role1', '0xABC123'))
+        .rejects.toEqual({ message: 'Log error' });
+    });
+  });
+
+  describe('getAllRulesWithLegacy', () => {
+    it('should return rules and legacy role when both exist', async () => {
+      const mockRules = [{ id: 1, server_id: 'server1' }];
+      const mockLegacy = [{ role_id: 'legacy-role', name: 'Legacy Server' }];
+      
+      mockSupabaseQuery.setResults([
+        { data: mockRules, error: null },
+        { data: mockLegacy, error: null }
+      ]);
+      
+      const result = await service.getAllRulesWithLegacy('server1');
+      
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual(mockRules[0]);
+      expect(result[1]).toEqual({
+        id: 'LEGACY',
+        channel_id: '-',
+        role_id: 'legacy-role',
+        slug: null,
+        attribute_key: null,
+        attribute_value: null,
+        min_items: null,
+        legacy: true,
+        server_name: 'Legacy Server'
+      });
+    });
+
+    it('should return only rules when no legacy role exists', async () => {
+      const mockRules = [{ id: 1, server_id: 'server1' }];
+      
+      mockSupabaseQuery.setResults([
+        { data: mockRules, error: null },
+        { data: [], error: null }
+      ]);
+      
+      const result = await service.getAllRulesWithLegacy('server1');
+      
+      expect(result).toEqual(mockRules);
+    });
+  });
+
+  describe('removeAllLegacyRoles', () => {
+    it('should remove legacy roles and return removed list', async () => {
+      const mockLegacyRoles = [{ role_id: 'legacy1', name: 'Legacy Role 1' }];
+      
+      mockSupabaseQuery.setResults([
+        { data: mockLegacyRoles, error: null },
+        { data: null, error: null }
+      ]);
+      
+      const result = await service.removeAllLegacyRoles('server1');
+      
+      expect(mockSupabaseQuery.delete).toHaveBeenCalled();
+      expect(result).toEqual({ removed: mockLegacyRoles });
+    });
+
+    it('should return empty array when no legacy roles exist', async () => {
+      mockSupabaseQuery.setResult({ data: [], error: null });
+      
+      const result = await service.removeAllLegacyRoles('server1');
+      
+      expect(result).toEqual({ removed: [] });
+    });
+  });
+
+  describe('getLegacyRoles', () => {
+    it('should return legacy roles data', async () => {
+      const mockData = [{ role_id: 'legacy1', name: 'Legacy Role' }];
+      mockSupabaseQuery.setResult({ data: mockData, error: null });
+      
+      const result = await service.getLegacyRoles('server1');
+      
+      expect(result).toEqual({ data: mockData, error: null });
+    });
+  });
+
+  describe('ruleExists', () => {
+    it('should return true when rule exists', async () => {
+      mockSupabaseQuery.setResult({ data: [{ id: 1 }], error: null });
+      
+      const result = await service.ruleExists('server1', 'channel1', 'role1', 'collection1');
+      
+      expect(result).toBe(true);
+    });
+
+    it('should return false when rule does not exist', async () => {
+      mockSupabaseQuery.setResult({ data: [], error: null });
+      
+      const result = await service.ruleExists('server1', 'channel1', 'role1', 'collection1');
+      
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('findRuleWithMessage', () => {
+    it('should return rule with message_id', async () => {
+      const mockRule = { id: 1, message_id: 'msg123' };
+      mockSupabaseQuery.setResult({ data: [mockRule], error: null });
+      
+      const result = await service.findRuleWithMessage('server1', 'channel1');
+      
+      expect(mockSupabaseQuery.not).toHaveBeenCalledWith('message_id', 'is', null);
+      expect(mockSupabaseQuery.limit).toHaveBeenCalledWith(1);
+      expect(result).toEqual(mockRule);
+    });
+
+    it('should return null when no rule with message found', async () => {
+      mockSupabaseQuery.setResult({ data: [], error: null });
+      
+      const result = await service.findRuleWithMessage('server1', 'channel1');
+      
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('updateRuleMessageId', () => {
+    it('should update message_id for rule', async () => {
+      mockSupabaseQuery.setResult({ data: null, error: null });
+      
+      await service.updateRuleMessageId(1, 'msg123');
+      
+      expect(mockSupabaseQuery.update).toHaveBeenCalledWith({ message_id: 'msg123' });
+      expect(mockSupabaseQuery.eq).toHaveBeenCalledWith('id', 1);
+    });
+
+    it('should handle update errors', async () => {
+      mockSupabaseQuery.setResult({ data: null, error: { message: 'Update error' } });
+      
+      await expect(service.updateRuleMessageId(1, 'msg123'))
+        .rejects.toEqual({ message: 'Update error' });
+    });
+  });
+
+  describe('findRuleByMessageId', () => {
+    it('should find rule by message_id', async () => {
+      const mockRule = { id: 1, message_id: 'msg123' };
+      mockSupabaseQuery.setResult({ data: [mockRule], error: null });
+      
+      const result = await service.findRuleByMessageId('server1', 'channel1', 'msg123');
+      
+      expect(mockSupabaseQuery.eq).toHaveBeenCalledWith('message_id', 'msg123');
+      expect(result).toEqual(mockRule);
+    });
+
+    it('should return null when no rule found', async () => {
+      mockSupabaseQuery.setResult({ data: [], error: null });
+      
+      const result = await service.findRuleByMessageId('server1', 'channel1', 'msg123');
+      
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('findRulesByMessageId', () => {
+    it('should find all rules by message_id', async () => {
+      const mockRules = [
+        { id: 1, message_id: 'msg123' },
+        { id: 2, message_id: 'msg123' }
+      ];
+      mockSupabaseQuery.setResult({ data: mockRules, error: null });
+      
+      const result = await service.findRulesByMessageId('server1', 'channel1', 'msg123');
+      
+      expect(result).toEqual(mockRules);
+    });
+
+    it('should return empty array when no rules found', async () => {
+      mockSupabaseQuery.setResult({ data: null, error: null });
+      
+      const result = await service.findRulesByMessageId('server1', 'channel1', 'msg123');
+      
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('getRulesByChannel', () => {
+    it('should get all rules for channel', async () => {
+      const mockRules = [{ id: 1, channel_id: 'channel1' }];
+      mockSupabaseQuery.setResult({ data: mockRules, error: null });
+      
+      const result = await service.getRulesByChannel('server1', 'channel1');
+      
+      expect(result).toEqual(mockRules);
+    });
+
+    it('should return empty array when no rules found', async () => {
+      mockSupabaseQuery.setResult({ data: null, error: null });
+      
+      const result = await service.getRulesByChannel('server1', 'channel1');
+      
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('findConflictingRule', () => {
+    it('should find conflicting rule', async () => {
+      const mockRule = { id: 1, role_id: 'role1' };
+      mockSupabaseQuery.setResult({ data: mockRule, error: null });
+      
+      const result = await service.findConflictingRule(
+        'server1', 'channel1', 'role1', 'collection1', 'trait', 'value', 1
+      );
+      
+      expect(mockSupabaseQuery.single).toHaveBeenCalled();
+      expect(result).toEqual(mockRule);
+    });
+
+    it('should handle no conflict found (PGRST116 error)', async () => {
+      mockSupabaseQuery.setResult({ 
+        data: null, 
+        error: { code: 'PGRST116', message: 'No rows found' } 
+      });
+      
+      const result = await service.findConflictingRule(
+        'server1', 'channel1', 'role1', 'collection1', 'trait', 'value', 1
+      );
+      
+      expect(result).toBeNull();
+    });
+
+    it('should throw other database errors', async () => {
+      mockSupabaseQuery.setResult({ 
+        data: null, 
+        error: { code: 'OTHER_ERROR', message: 'Database error' } 
+      });
+      
+      await expect(service.findConflictingRule(
+        'server1', 'channel1', 'role1', 'collection1', 'trait', 'value', 1
+      )).rejects.toEqual({ code: 'OTHER_ERROR', message: 'Database error' });
+    });
+  });
+
+  describe('checkForExactDuplicateRule', () => {
+    it('should find exact duplicate rule', async () => {
+      const mockRule = { id: 1, role_id: 'role1' };
+      mockSupabaseQuery.setResult({ data: [mockRule], error: null });
+      
+      const result = await service.checkForExactDuplicateRule(
+        'server1', 'channel1', 'collection1', 'trait', 'value', 1, 'role1'
+      );
+      
+      expect(mockSupabaseQuery.eq).toHaveBeenCalledWith('role_id', 'role1');
+      expect(result).toEqual(mockRule);
+    });
+
+    it('should return null when no exact duplicate found', async () => {
+      mockSupabaseQuery.setResult({ data: [], error: null });
+      
+      const result = await service.checkForExactDuplicateRule(
+        'server1', 'channel1', 'collection1', 'trait', 'value', 1, 'role1'
+      );
+      
+      expect(result).toBeNull();
+    });
+
+    it('should handle database errors', async () => {
+      mockSupabaseQuery.setResult({ 
+        data: null, 
+        error: { message: 'Database error' } 
+      });
+      
+      await expect(service.checkForExactDuplicateRule(
+        'server1', 'channel1', 'collection1', 'trait', 'value', 1, 'role1'
+      )).rejects.toEqual({ message: 'Database error' });
+    });
+  });
+});

--- a/backend/test/discord.service.spec.ts.backup
+++ b/backend/test/discord.service.spec.ts.backup
@@ -22,6 +22,7 @@ const mockGuild = {
   }
 };
 const mockRole = { id: 'role123', name: 'TestRole', position: 5, editable: true };
+const mockChannel = { id: 'channel123', type: 0 };
 
 const mockClient = {
   on: jest.fn(),
@@ -108,7 +109,7 @@ const mockDiscordCommandsService = {
   handleMigrateLegacyRule: jest.fn(),
 };
 
-describe('DiscordService - Enhanced Tests', () => {
+describe('DiscordService', () => {
   let service: DiscordService;
   let originalEnv: NodeJS.ProcessEnv;
 
@@ -140,9 +141,6 @@ describe('DiscordService - Enhanced Tests', () => {
     }).compile();
     service = module.get<DiscordService>(DiscordService);
     jest.clearAllMocks();
-    
-    // Set up client for tests that need it
-    (service as any).client = mockClient;
   });
 
   describe('Initialization', () => {
@@ -150,67 +148,48 @@ describe('DiscordService - Enhanced Tests', () => {
       expect(service).toBeDefined();
     });
 
-    it('should initialize bot successfully', async () => {
-      // Reset client to null to test initialization
-      (service as any).client = null;
+    it('should initialize bot when DISCORD env is enabled', async () => {
+      // Mock environment to enable Discord
+      const originalDiscord = process.env.DISCORD;
+      process.env.DISCORD = '1';
+
+      // Create new service instance
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          DiscordService,
+          { provide: NonceService, useValue: mockNonceService },
+          { provide: DbService, useValue: mockDbService },
+          { provide: DiscordMessageService, useValue: mockDiscordMessageService },
+          { provide: DiscordVerificationService, useValue: mockDiscordVerificationService },
+          { provide: DiscordCommandsService, useValue: mockDiscordCommandsService },
+        ],
+      }).compile();
+
+      const newService = module.get<DiscordService>(DiscordService);
       
-      let readyCallback: Function;
-      mockClient.on.mockImplementation((event, callback) => {
-        if (event === 'ready') {
-          readyCallback = callback;
-        }
-      });
-
-      const initPromise = service.initializeBot();
-      
-      // Simulate ready event
-      if (readyCallback) {
-        readyCallback(mockClient);
-      }
-
-      await initPromise;
-
+      // Verify initializeBot was called indirectly through constructor
+      expect(mockClient.on).toHaveBeenCalled();
       expect(mockClient.login).toHaveBeenCalledWith('test-token');
-      expect(mockDiscordMessageService.initialize).toHaveBeenCalledWith(mockClient);
-      expect(mockDiscordVerificationService.initialize).toHaveBeenCalledWith(mockClient);
-      expect(mockDiscordCommandsService.initialize).toHaveBeenCalledWith(mockClient);
-    });
 
-    it('should not initialize bot multiple times', async () => {
-      // Reset client to null to test the guard clause
-      (service as any).client = null;
-      
-      // First initialization
-      let readyCallback: Function;
-      mockClient.on.mockImplementation((event, callback) => {
-        if (event === 'ready') {
-          readyCallback = callback;
-        }
-      });
-
-      const initPromise1 = service.initializeBot();
-      
-      // Trigger ready event for first init
-      if (readyCallback) {
-        readyCallback(mockClient);
-      }
-      
-      await initPromise1;
-      
-      // Clear mock calls from first initialization
-      mockClient.login.mockClear();
-      
-      // Second call should be no-op since client is now set
-      await service.initializeBot();
-      
-      expect(mockClient.login).toHaveBeenCalledTimes(0); // Should not be called again
+      // Restore environment
+      process.env.DISCORD = originalDiscord;
     });
 
     it('should handle bot initialization errors', async () => {
-      // This test verifies error handling in the login process
-      // We skip the actual promise rejection test due to the complex async nature
-      // of the initializeBot method with event listeners
-      expect(true).toBe(true); // Placeholder for complex async error handling
+      const loggerErrorSpy = jest.spyOn(Logger, 'error').mockImplementation();
+      mockClient.login.mockRejectedValueOnce(new Error('Login failed'));
+
+      // Call initializeBot directly to test error handling
+      await expect(service.initializeBot()).rejects.toThrow('Login failed');
+      
+      loggerErrorSpy.mockRestore();
+    });
+
+    it('should not initialize bot multiple times', async () => {
+      await service.initializeBot();
+      await service.initializeBot(); // Second call should be no-op
+      
+      expect(mockClient.login).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -242,10 +221,6 @@ describe('DiscordService - Enhanced Tests', () => {
   });
 
   describe('Discord API Interactions', () => {
-    beforeEach(() => {
-      mockGuild.roles.fetch.mockResolvedValue(mockRole);
-    });
-
     describe('getUser', () => {
       it('should fetch user successfully', async () => {
         const result = await service.getUser('user123');
@@ -270,6 +245,7 @@ describe('DiscordService - Enhanced Tests', () => {
 
       it('should handle no client initialized', async () => {
         const loggerWarnSpy = jest.spyOn(Logger, 'warn').mockImplementation();
+        // Temporarily remove client
         (service as any).client = null;
         
         const result = await service.getUser('user123');
@@ -278,6 +254,7 @@ describe('DiscordService - Enhanced Tests', () => {
         expect(loggerWarnSpy).toHaveBeenCalledWith('Discord client not initialized when fetching user');
         loggerWarnSpy.mockRestore();
         
+        // Restore client for other tests
         (service as any).client = mockClient;
       });
     });
@@ -319,6 +296,10 @@ describe('DiscordService - Enhanced Tests', () => {
     });
 
     describe('getRole', () => {
+      beforeEach(() => {
+        mockGuild.roles.fetch.mockResolvedValue(mockRole);
+      });
+
       it('should fetch role successfully', async () => {
         const result = await service.getRole('guild123', 'role123');
         
@@ -357,10 +338,14 @@ describe('DiscordService - Enhanced Tests', () => {
   });
 
   describe('Command Handling', () => {
-    it('should handle add-rule command', async () => {
+
+  describe('Command Handling', () => {
+    it('add-rule delegates to DiscordCommandsService', async () => {
       const mockInteraction = {
         options: { getSubcommand: () => 'add-rule' },
         guild: { id: 'g' },
+        isChatInputCommand: () => true,
+        isButton: () => false,
         deferred: false,
         replied: false
       } as any;
@@ -369,10 +354,12 @@ describe('DiscordService - Enhanced Tests', () => {
       expect(mockDiscordCommandsService.handleAddRule).toHaveBeenCalledWith(mockInteraction);
     });
 
-    it('should handle remove-rule command', async () => {
+    it('remove-rule delegates to DiscordCommandsService', async () => {
       const mockInteraction = {
         options: { getSubcommand: () => 'remove-rule' },
         guild: { id: 'g' },
+        isChatInputCommand: () => true,
+        isButton: () => false,
         deferred: false,
         replied: false
       } as any;
@@ -381,10 +368,12 @@ describe('DiscordService - Enhanced Tests', () => {
       expect(mockDiscordCommandsService.handleRemoveRule).toHaveBeenCalledWith(mockInteraction);
     });
 
-    it('should handle list-rules command', async () => {
+    it('list-rules delegates to DiscordCommandsService', async () => {
       const mockInteraction = {
         options: { getSubcommand: () => 'list-rules' },
         guild: { id: 'g' },
+        isChatInputCommand: () => true,
+        isButton: () => false,
         deferred: false,
         replied: false
       } as any;
@@ -393,10 +382,12 @@ describe('DiscordService - Enhanced Tests', () => {
       expect(mockDiscordCommandsService.handleListRules).toHaveBeenCalledWith(mockInteraction);
     });
 
-    it('should handle recover-verification command', async () => {
+    it('recover-verification delegates to DiscordCommandsService', async () => {
       const mockInteraction = {
         options: { getSubcommand: () => 'recover-verification' },
         guild: { id: 'g' },
+        isChatInputCommand: () => true,
+        isButton: () => false,
         deferred: false,
         replied: false
       } as any;
@@ -468,29 +459,34 @@ describe('DiscordService - Enhanced Tests', () => {
   });
 
   describe('Service Delegation', () => {
-    it('should delegate requestVerification to DiscordVerificationService', async () => {
-      const mockInteraction = { customId: 'requestVerification' } as any;
+    it('requestVerification delegates to DiscordVerificationService', async () => {
+      const mockInteraction = {
+        customId: 'requestVerification',
+        guild: { id: 'g' },
+        isChatInputCommand: () => false,
+        isButton: () => true,
+      } as any;
       
       await service.requestVerification(mockInteraction);
       expect(mockDiscordVerificationService.requestVerification).toHaveBeenCalledWith(mockInteraction);
     });
 
-    it('should delegate addUserRole to DiscordVerificationService', async () => {
+    it('addUserRole delegates to DiscordVerificationService', async () => {
       await service.addUserRole('userId', 'roleId', 'guildId', 'address', 'nonce');
       expect(mockDiscordVerificationService.addUserRole).toHaveBeenCalledWith('userId', 'roleId', 'guildId', 'address', 'nonce');
     });
 
-    it('should delegate throwError to DiscordVerificationService', async () => {
+    it('throwError delegates to DiscordVerificationService', async () => {
       await service.throwError('nonce', 'error message');
       expect(mockDiscordVerificationService.throwError).toHaveBeenCalledWith('nonce', 'error message');
     });
 
-    it('should delegate getVerificationRoleId to DiscordVerificationService', async () => {
+    it('getVerificationRoleId delegates to DiscordVerificationService', async () => {
       await service.getVerificationRoleId('guildId', 'channelId', 'messageId');
       expect(mockDiscordVerificationService.getVerificationRoleId).toHaveBeenCalledWith('guildId', 'channelId', 'messageId');
     });
 
-    it('should delegate findExistingVerificationMessage to DiscordMessageService', async () => {
+    it('findExistingVerificationMessage delegates to DiscordMessageService', async () => {
       const mockChannel = { id: 'channelId' } as any;
       await service.findExistingVerificationMessage(mockChannel);
       expect(mockDiscordMessageService.findExistingVerificationMessage).toHaveBeenCalledWith(mockChannel);
@@ -498,9 +494,15 @@ describe('DiscordService - Enhanced Tests', () => {
   });
 
   describe('Role Autocomplete', () => {
+    beforeEach(() => {
+      // Set up client for autocomplete tests
+      (service as any).client = mockClient;
+    });
+
     it('should filter roles by focused value and bot permissions', async () => {
       const role1 = { id: 'role1', name: 'admin', position: 5, editable: true };
       const role2 = { id: 'role2', name: 'moderator', position: 3, editable: true };
+      const role3 = { id: 'role3', name: 'user', position: 15, editable: false }; // Too high position
       
       const mockGuildWithRoles = {
         members: { me: { roles: { highest: { position: 10 } } } },
@@ -539,14 +541,20 @@ describe('DiscordService - Enhanced Tests', () => {
         editable: true
       };
 
+      const botMember = {
+        roles: {
+          highest: { position: 5 }
+        }
+      };
+
       const mockGuild = {
-        members: { me: { roles: { highest: { position: 5 } } } },
+        members: { me: botMember },
         roles: {
           cache: {
             filter: jest.fn().mockReturnThis(),
             sort: jest.fn().mockReturnThis(),
             first: jest.fn().mockReturnValue([existingRole]),
-            find: jest.fn().mockReturnValue(existingRole)
+            find: jest.fn().mockReturnValue(existingRole) // Found existing role
           }
         }
       };
@@ -563,18 +571,24 @@ describe('DiscordService - Enhanced Tests', () => {
 
       expect(mockInteraction.respond).toHaveBeenCalledWith([
         { name: 'poop', value: 'poop' }
-      ]);
+      ]); // Should only show existing role, no "Create new role" option
     });
 
     it('should suggest creating new role when role does not exist', async () => {
+      const botMember = {
+        roles: {
+          highest: { position: 5 }
+        }
+      };
+
       const mockGuild = {
-        members: { me: { roles: { highest: { position: 5 } } } },
+        members: { me: botMember },
         roles: {
           cache: {
             filter: jest.fn().mockReturnThis(),
             sort: jest.fn().mockReturnThis(),
-            first: jest.fn().mockReturnValue([]),
-            find: jest.fn().mockReturnValue(undefined)
+            first: jest.fn().mockReturnValue([]), // No matching roles found
+            find: jest.fn().mockReturnValue(undefined) // No existing role with this name
           }
         }
       };
@@ -591,7 +605,7 @@ describe('DiscordService - Enhanced Tests', () => {
 
       expect(mockInteraction.respond).toHaveBeenCalledWith([
         { name: '💡 Create new role: "unique-role-name"', value: 'unique-role-name' }
-      ]);
+      ]); // Should show "Create new role" option
     });
 
     it('should handle no guild in interaction', async () => {
@@ -630,7 +644,7 @@ describe('DiscordService - Enhanced Tests', () => {
     it('should handle autocomplete errors gracefully', async () => {
       const loggerErrorSpy = jest.spyOn(Logger, 'error').mockImplementation();
       const mockInteraction = {
-        guild: { members: { me: null } },
+        guild: { members: { me: null } }, // This will cause an error
         options: {
           getFocused: jest.fn().mockImplementation(() => {
             throw new Error('Autocomplete error');
@@ -647,6 +661,7 @@ describe('DiscordService - Enhanced Tests', () => {
     });
 
     it('should limit autocomplete choices to 24 roles plus create option', async () => {
+      // Create 30 roles to test the limit
       const roles = Array.from({ length: 30 }, (_, i) => ({
         id: `role${i}`,
         name: `role${i}`,
@@ -660,7 +675,7 @@ describe('DiscordService - Enhanced Tests', () => {
           cache: {
             filter: jest.fn().mockReturnThis(),
             sort: jest.fn().mockReturnThis(),
-            first: jest.fn().mockReturnValue(roles.slice(0, 24)),
+            first: jest.fn().mockReturnValue(roles.slice(0, 24)), // Discord limits to 24
             find: jest.fn().mockReturnValue(undefined)
           }
         }
@@ -682,12 +697,39 @@ describe('DiscordService - Enhanced Tests', () => {
       ];
 
       expect(mockInteraction.respond).toHaveBeenCalledWith(expectedChoices);
-      expect(expectedChoices.length).toBe(25);
+      expect(expectedChoices.length).toBe(25); // 24 roles + 1 create option
     });
   });
 
   describe('Event Handling', () => {
-    it('should handle interaction create events for autocomplete', async () => {
+    it('should handle client ready event during initialization', async () => {
+      const loggerDebugSpy = jest.spyOn(Logger, 'debug').mockImplementation();
+      
+      // Simulate the ready event
+      let readyCallback: Function;
+      mockClient.on.mockImplementation((event, callback) => {
+        if (event === 'ready') {
+          readyCallback = callback;
+        }
+      });
+
+      const initPromise = service.initializeBot();
+      
+      // Trigger the ready event
+      if (readyCallback) {
+        readyCallback(mockClient);
+      }
+
+      await initPromise;
+
+      expect(mockDiscordMessageService.initialize).toHaveBeenCalledWith(mockClient);
+      expect(mockDiscordVerificationService.initialize).toHaveBeenCalledWith(mockClient);
+      expect(mockDiscordCommandsService.initialize).toHaveBeenCalledWith(mockClient);
+      
+      loggerDebugSpy.mockRestore();
+    });
+
+    it('should handle interaction create events', async () => {
       let interactionCallback: Function;
       mockClient.on.mockImplementation((event, callback) => {
         if (event === 'interactionCreate') {
@@ -697,6 +739,7 @@ describe('DiscordService - Enhanced Tests', () => {
 
       await service.createSlashCommands();
 
+      // Test autocomplete interaction
       const autocompleteInteraction = {
         isAutocomplete: () => true,
         isChatInputCommand: () => false,
@@ -716,18 +759,8 @@ describe('DiscordService - Enhanced Tests', () => {
 
       expect(handleRoleAutocompleteSpy).toHaveBeenCalledWith(autocompleteInteraction);
       handleRoleAutocompleteSpy.mockRestore();
-    });
 
-    it('should handle interaction create events for chat input commands', async () => {
-      let interactionCallback: Function;
-      mockClient.on.mockImplementation((event, callback) => {
-        if (event === 'interactionCreate') {
-          interactionCallback = callback;
-        }
-      });
-
-      await service.createSlashCommands();
-
+      // Test chat input command interaction
       const commandInteraction = {
         isAutocomplete: () => false,
         isChatInputCommand: () => true,
@@ -743,18 +776,8 @@ describe('DiscordService - Enhanced Tests', () => {
 
       expect(handleSetupSpy).toHaveBeenCalledWith(commandInteraction);
       handleSetupSpy.mockRestore();
-    });
 
-    it('should handle interaction create events for button interactions', async () => {
-      let interactionCallback: Function;
-      mockClient.on.mockImplementation((event, callback) => {
-        if (event === 'interactionCreate') {
-          interactionCallback = callback;
-        }
-      });
-
-      await service.createSlashCommands();
-
+      // Test button interaction
       const buttonInteraction = {
         isAutocomplete: () => false,
         isChatInputCommand: () => false,

--- a/backend/test/jest-console-setup.js
+++ b/backend/test/jest-console-setup.js
@@ -44,7 +44,13 @@ if (typeof process !== 'undefined' && process.stdout && process.stderr) {
   };
   
   process.stderr.write = function(chunk, encoding, callback) {
-    // Suppress all stderr during tests (including NestJS Logger errors)
+    // Allow test failures and Jest error messages to show through
+    if (typeof chunk === 'string') {
+      if (chunk.includes('FAIL') || chunk.includes('Error:') || chunk.includes('expect(')) {
+        return originalStderrWrite.call(this, chunk, encoding, callback);
+      }
+    }
+    // Suppress other stderr during tests
     if (typeof callback === 'function') {
       callback();
     }


### PR DESCRIPTION
This pull request updates the `jest-console-setup.js` file to refine the handling of `stderr` output during tests. The change allows critical test failure messages and Jest error messages to be displayed, while continuing to suppress other `stderr` output.

Key change:

* [`backend/test/jest-console-setup.js`](diffhunk://#diff-4b1748ef98c335f4e75c7ba5c328d1f658875b1439f5f87c6da2e77679f8ba8aL47-R53): Modified the `process.stderr.write` function to allow specific `stderr` messages containing "FAIL," "Error:", or "expect(" to pass through, ensuring visibility of test failures and Jest errors during testing.