### PR TITLE
feat: Improve role handling by adding @ prefix in Discord cmds and tests

### DIFF
--- a/backend/src/services/discord-commands.service.ts
+++ b/backend/src/services/discord-commands.service.ts
@@ -289,7 +289,7 @@ export class DiscordCommandsService {
       // Use existing verification message
       const embed = AdminFeedback.success(
         isDuplicateConfirmed ? 'Duplicate Rule Created' : 'Rule Added',
-        `Rule ${newRule.id} for <#${channel.id}> and <@&${role.id}> ${hasExistingMessage ? 'added using existing verification message' : 'created'}.`,
+        `Rule ${newRule.id} for <#${channel.id}> and <@&${role.id}> ${hasExistingMessage ? 'has been added using existing verification message' : 'created'}.`,
         [
           { name: 'Collection', value: slug, inline: true },
           { name: 'Attribute', value: AdminFeedback.formatRule(newRule).split('\n')[2].replace('**Attribute:** ', ''), inline: true },
@@ -375,7 +375,7 @@ export class DiscordCommandsService {
 
       const embed = AdminFeedback.success(
         isDuplicateConfirmed ? 'Duplicate Rule Created' : 'Rule Added',
-        `Rule ${newRule.id} for <#${channel.id}> and <@&${role.id}> ${messageCreated ? 'added with new verification message' : 'added using existing verification message'}.`,
+        `Rule ${newRule.id} for <#${channel.id}> and <@&${role.id}> ${messageCreated ? 'has been added with new verification message' : 'has been added using existing verification message'}.`,
         [
           { name: 'Collection', value: slug, inline: true },
           { name: 'Attribute', value: formatAttribute(attributeKey, attributeValue), inline: true },
@@ -694,9 +694,12 @@ export class DiscordCommandsService {
     interaction: ChatInputCommandInteraction, 
     roleName: string
   ): Promise<Role | null> {
+    // Strip @ prefix if present (users can enter @RoleName or RoleName)
+    const cleanRoleName = roleName.startsWith('@') ? roleName.slice(1) : roleName;
+    
     // Try to find existing role (including ones we can't manage)
     let role = interaction.guild.roles.cache.find(r => 
-      r.name.toLowerCase() === roleName.toLowerCase()
+      r.name.toLowerCase() === cleanRoleName.toLowerCase()
     );
 
     // If role exists, check if we can manage it or provide appropriate error
@@ -705,11 +708,11 @@ export class DiscordCommandsService {
         await interaction.editReply({
           embeds: [AdminFeedback.error(
             'Role Hierarchy Issue',
-            `A role named "${roleName}" already exists but is positioned higher than the bot's role. The bot cannot manage this role.`,
+            `A role named "${cleanRoleName}" already exists but is positioned higher than the bot's role. The bot cannot manage this role.`,
             [
               'Use a different role name',
               'Move the bot\'s role higher in the server settings',
-              `Ask an admin to move the "${roleName}" role below the bot's role`
+              `Ask an admin to move the "${cleanRoleName}" role below the bot's role`
             ]
           )]
         });
@@ -722,14 +725,14 @@ export class DiscordCommandsService {
     // If role doesn't exist, create it
     // Double-check that no role with this name exists anywhere in the server
     const existingRoleWithName = interaction.guild.roles.cache.find(r => 
-      r.name.toLowerCase() === roleName.toLowerCase()
+      r.name.toLowerCase() === cleanRoleName.toLowerCase()
     );
     
     if (existingRoleWithName) {
       await interaction.editReply({
         embeds: [AdminFeedback.error(
           'Duplicate Role Name',
-          `A role named "${roleName}" already exists in this server.`,
+          `A role named "${cleanRoleName}" already exists in this server.`,
           ['Choose a different name for the new role']
         )]
       });
@@ -748,7 +751,7 @@ export class DiscordCommandsService {
       }
 
       role = await interaction.guild.roles.create({
-        name: roleName,
+        name: cleanRoleName,
         color: 'Blue', // Default color
         position: position,
         reason: `Auto-created for verification rule by ${interaction.user.tag}`
@@ -765,7 +768,7 @@ export class DiscordCommandsService {
       await interaction.editReply({
         embeds: [AdminFeedback.error(
           'Role Creation Failed',
-          `Failed to create role "${roleName}": ${error.message}`,
+          `Failed to create role "${cleanRoleName}": ${error.message}`,
           ['Try again with a different role name']
         )]
       });
@@ -796,7 +799,7 @@ export class DiscordCommandsService {
     
     // Create detailed rule info fields
     const ruleInfoFields = this.createRuleInfoFields(removedRuleData);
-    const embed = AdminFeedback.success('Rule Removed', `Rule ${ruleId} for ${removedRuleData.channel_name} and @${removedRuleData.role_name} removed.`);
+    const embed = AdminFeedback.success('Rule Removed', `Rule ${ruleId} for ${removedRuleData.channel_name} and @${removedRuleData.role_name} has been removed.`);
     embed.addFields(ruleInfoFields);
 
     const messageContent = {
@@ -973,7 +976,7 @@ export class DiscordCommandsService {
       
       // Create detailed rule info fields
       const ruleInfoFields = this.createRuleInfoFields(restoredRule);
-      const embed = AdminFeedback.success('Rule Removed', `Rule ${restoredRule.id} for ${restoredRule.channel_name} and @${restoredRule.role_name} removed.`);
+      const embed = AdminFeedback.success('Rule Removed', `Rule ${restoredRule.id} for ${restoredRule.channel_name} and @${restoredRule.role_name} has been removed.`);
       embed.addFields(ruleInfoFields);
       
       await interaction.reply({
@@ -1138,7 +1141,7 @@ export class DiscordCommandsService {
       
       // Create detailed rule info fields
       const ruleInfoFields = this.createRuleInfoFields(createdRule);
-      const embed = AdminFeedback.success('Rule Added', `Rule ${createdRule.id} for ${cancelledRule.channel.name} and @${cancelledRule.role.name} added using existing verification message.`);
+      const embed = AdminFeedback.success('Rule Added', `Rule ${createdRule.id} for ${cancelledRule.channel.name} and @${cancelledRule.role.name} has been added using existing verification message.`);
       embed.addFields(ruleInfoFields);
       
       // Create Undo button

--- a/backend/src/services/discord.service.ts
+++ b/backend/src/services/discord.service.ts
@@ -498,10 +498,13 @@ export class DiscordService {
         .sort((a, b) => a.name.localeCompare(b.name))
         .first(24); // Discord allows max 25 choices, save 1 for "create new" option
 
-      const choices = roles.map(role => ({
-        name: role.name,
-        value: role.name
-      }));
+      const choices = roles.map(role => {
+        // Format with @ prefix for better UX
+        return {
+          name: `@${role.name}`,
+          value: role.name
+        };
+      });
 
       // Check if any role (manageable or not) already exists with the focused value
       const existingRoleWithName = guild.roles.cache.find(role => 


### PR DESCRIPTION
This pull request introduces several updates to the `DiscordCommandsService` and `DiscordService` classes, as well as their corresponding tests. The changes focus on improving user experience with role handling, enhancing feedback messages, and adding new test cases to ensure robust functionality. The most significant updates include handling role names with an `@` prefix, refining feedback messages for rule and role operations, and enhancing test coverage.

### Updates to Role Handling:
* Added logic to clean role names by stripping the `@` prefix if present, ensuring consistent handling for both new role creation and existing role lookup. (`backend/src/services/discord-commands.service.ts`, [[1]](diffhunk://#diff-de3f524b0d1dd03b44be9c5aa263c0bc94afdb094969dd1aa20d7f0949cbb02fR697-R702) [[2]](diffhunk://#diff-de3f524b0d1dd03b44be9c5aa263c0bc94afdb094969dd1aa20d7f0949cbb02fL708-R715) [[3]](diffhunk://#diff-de3f524b0d1dd03b44be9c5aa263c0bc94afdb094969dd1aa20d7f0949cbb02fL725-R735) [[4]](diffhunk://#diff-de3f524b0d1dd03b44be9c5aa263c0bc94afdb094969dd1aa20d7f0949cbb02fL751-R754) [[5]](diffhunk://#diff-de3f524b0d1dd03b44be9c5aa263c0bc94afdb094969dd1aa20d7f0949cbb02fL768-R771)

### Improvements to Feedback Messages:
* Refined feedback messages to use more natural phrasing, such as "has been added" or "has been removed," across multiple operations for better readability. (`backend/src/services/discord-commands.service.ts`, [[1]](diffhunk://#diff-de3f524b0d1dd03b44be9c5aa263c0bc94afdb094969dd1aa20d7f0949cbb02fL292-R292) [[2]](diffhunk://#diff-de3f524b0d1dd03b44be9c5aa263c0bc94afdb094969dd1aa20d7f0949cbb02fL378-R378) [[3]](diffhunk://#diff-de3f524b0d1dd03b44be9c5aa263c0bc94afdb094969dd1aa20d7f0949cbb02fL799-R802) [[4]](diffhunk://#diff-de3f524b0d1dd03b44be9c5aa263c0bc94afdb094969dd1aa20d7f0949cbb02fL976-R979) [[5]](diffhunk://#diff-de3f524b0d1dd03b44be9c5aa263c0bc94afdb094969dd1aa20d7f0949cbb02fL1141-R1144)

### Enhancements to Role Autocomplete:
* Updated role autocomplete to format role names with an `@` prefix for improved user experience and added support for displaying role colors when applicable. (`backend/src/services/discord.service.ts`, [[1]](diffhunk://#diff-f4f7eaa546e192917a87a7fe97c6c24e6abd71d7f1a248374cb8050c0952eb71L501-R507) [[2]](diffhunk://#diff-26670035b4f8b097a1030593ef07160b2eceedf4449f5822c9cd912415be152cL533-R534) [[3]](diffhunk://#diff-26670035b4f8b097a1030593ef07160b2eceedf4449f5822c9cd912415be152cL570-R570) [[4]](diffhunk://#diff-26670035b4f8b097a1030593ef07160b2eceedf4449f5822c9cd912415be152cL685-R724)

### Additions to Test Coverage:
* Introduced new test cases to validate handling of role names with an `@` prefix for both new role creation and existing role lookup. (`backend/test/discord-commands.service.spec.ts`, [backend/test/discord-commands.service.spec.tsR1396-R1524](diffhunk://#diff-1e38c18852d1202f824afdd6f1fa57097282f5b7f8bf42cb038301773e95478aR1396-R1524))
* Enhanced tests for role autocomplete to verify proper formatting and color display for roles. (`backend/test/discord.service.spec.ts`, [backend/test/discord.service.spec.tsL685-R724](diffhunk://#diff-26670035b4f8b097a1030593ef07160b2eceedf4449f5822c9cd912415be152cL685-R724))

These changes collectively improve the functionality, user experience, and reliability of the Discord bot's role and rule management features.