### PR TITLE
fix: lots of stuff

### DIFF
--- a/backend/src/services/data.service.ts
+++ b/backend/src/services/data.service.ts
@@ -202,8 +202,8 @@ export class DataService {
         // This is important for correct rarity calculations and occurrence counts
         const allData = [];
         let page = 0;
-        const pageSize = 1000; // Balanced page size for performance
-        const maxPages = 10; // Allow up to 10k records to capture full collections
+        const pageSize = 2000; // Balanced page size for performance
+        const maxPages = 5; // Allow up to 10k records to capture full collections
 
         console.log(`📊 [DataService] Starting full pagination for slug: "${slug}"`);
 

--- a/backend/src/services/discord-commands.service.ts
+++ b/backend/src/services/discord-commands.service.ts
@@ -153,7 +153,7 @@ export class DiscordCommandsService {
           min_items: ruleData.minItems
         };
         const ruleInfoFields = this.duplicateRuleConfirmationHandler.createRuleInfoFields(cancelledRuleFormatted);
-        const embed = AdminFeedback.info('Rule Creation Cancelled', `Proposed rule for ${ruleData.channel.name} and @${ruleData.role.name} was not created.`);
+        const embed = AdminFeedback.destructive('Rule Creation Cancelled', `Proposed rule for ${ruleData.channel.name} and @${ruleData.role.name} was not created.`);
         embed.addFields(ruleInfoFields);
         
         // Create Undo button
@@ -602,12 +602,6 @@ export class DiscordCommandsService {
         position: position,
         reason: `Auto-created for verification rule by ${interaction.user.tag}`
       });
-      
-      // Send a follow-up message about role creation
-      await interaction.followUp({
-        content: AdminFeedback.simple(`Created new role: **${role.name}**`),
-        ephemeral: true
-      });
 
       return { role, wasNewlyCreated: true };
     } catch (error) {
@@ -645,7 +639,7 @@ export class DiscordCommandsService {
     
     // Create detailed rule info fields
     const ruleInfoFields = this.duplicateRuleConfirmationHandler.createRuleInfoFields(removedRuleData);
-    const embed = AdminFeedback.success('Rule Removed', `Rule ${ruleId} for ${removedRuleData.channel_name} and @${removedRuleData.role_name} has been removed.`);
+    const embed = AdminFeedback.destructive('Rule Removed', `Rule ${ruleId} for ${removedRuleData.channel_name} and @${removedRuleData.role_name} has been removed.`);
     embed.addFields(ruleInfoFields);
 
     const messageContent = {
@@ -712,7 +706,7 @@ export class DiscordCommandsService {
       });
     }
 
-    const embed = AdminFeedback.success(
+    const embed = AdminFeedback.destructive(
       successful.length === 1 ? 'Rule Removed' : `${successful.length} Rules Removed`, 
       description.trim()
     );
@@ -1039,7 +1033,7 @@ export class DiscordCommandsService {
           min_items: ruleData.minItems
         };
         const ruleInfoFields = this.duplicateRuleConfirmationHandler.createRuleInfoFields(cancelledRuleFormatted);
-        const embed = AdminFeedback.info('Rule Creation Cancelled', `Proposed rule for ${ruleData.channel.name} and @${ruleData.role.name} was not created.`);
+        const embed = AdminFeedback.destructive('Rule Creation Cancelled', `Proposed rule for ${ruleData.channel.name} and @${ruleData.role.name} was not created.`);
         embed.addFields(ruleInfoFields);
         
         // Create Undo button using the same chain ID
@@ -1079,7 +1073,7 @@ export class DiscordCommandsService {
         // Timeout - clean up
         this.duplicateRuleConfirmationHandler.deletePendingRule(chainId);
         interaction.editReply({
-          embeds: [AdminFeedback.info('Request Timed Out', 'Rule creation was cancelled due to timeout.')],
+          embeds: [AdminFeedback.warning('Request Timed Out', 'Rule creation was cancelled due to timeout.')],
           components: []
         }).catch(() => {}); // Ignore errors if interaction is no longer valid
       }

--- a/backend/src/services/discord-commands/handlers/remove-rule.handler.ts
+++ b/backend/src/services/discord-commands/handlers/remove-rule.handler.ts
@@ -242,7 +242,7 @@ export class RemoveRuleHandler {
       attribute_value: removedRuleData.attribute_value,
       min_items: removedRuleData.min_items
     });
-    const embed = AdminFeedback.success(
+    const embed = AdminFeedback.destructive(
       'Rule Removed', 
       `Rule ${ruleId} for ${removedRuleData.channel_name} and @${removedRuleData.role_name} has been removed.`
     );
@@ -301,7 +301,7 @@ export class RemoveRuleHandler {
       });
     }
 
-    const embed = AdminFeedback.success(
+    const embed = AdminFeedback.destructive(
       successful.length === 1 ? 'Rule Removed' : `${successful.length} Rules Removed`, 
       description.trim()
     );

--- a/backend/src/services/discord-commands/interactions/removal-undo.interaction.ts
+++ b/backend/src/services/discord-commands/interactions/removal-undo.interaction.ts
@@ -288,17 +288,32 @@ export class RemovalUndoInteractionHandler {
     // Store the restored rule for potential undo using the chain ID
     const restoredRuleWithMetadata = {
       ...recreatedRule,
-      wasNewlyCreated: removedRule.wasNewlyCreated
+      wasNewlyCreated: removedRule.wasNewlyCreated,
+      isDuplicateRule: removedRule.isDuplicateRule,
+      duplicateType: removedRule.duplicateType
     };
     this.restoredRules.set(chainId, restoredRuleWithMetadata);
     
     // Create rule info fields for the restored rule
     const ruleInfoFields = this.createRuleInfoFields(removedRule);
+    const embedTitle = removedRule.isDuplicateRule ? 'Duplicate Rule Restored' : 'Rule Restored';
     const embed = AdminFeedback.success(
-      'Rule Restored', 
-      `Rule ${recreatedRule.id} for ${removedRule.channel_name} and @${removedRule.role_name} has been restored.`
+      embedTitle, 
+      `Rule ${recreatedRule.id} for <#${removedRule.channel_id}> and <@&${removedRule.role_id}> has been restored.`
     );
     embed.addFields(ruleInfoFields);
+    
+    // Add duplicate context note if applicable
+    if (removedRule.isDuplicateRule && removedRule.duplicateType) {
+      const noteText = removedRule.duplicateType === 'role' 
+        ? 'This role again has multiple ways to be earned in this channel.'
+        : 'Users meeting these criteria will again receive multiple roles.';
+      embed.addFields({
+        name: '⚠️ Note',
+        value: noteText,
+        inline: false
+      });
+    }
     
     // Create undo button for the restoration using the chain ID
     const components = [

--- a/backend/src/services/discord-commands/utils/role-management.util.ts
+++ b/backend/src/services/discord-commands/utils/role-management.util.ts
@@ -77,12 +77,6 @@ export async function findOrCreateRole(
       position: position,
       reason: `Auto-created for verification rule by ${interaction.user.tag}`
     });
-    
-    // Send a follow-up message about role creation
-    await interaction.followUp({
-      content: AdminFeedback.simple(`Created new role: **${role.name}**`),
-      ephemeral: true
-    });
 
     return { role, wasNewlyCreated: true };
   } catch (error) {

--- a/backend/src/services/utils/admin-feedback.util.ts
+++ b/backend/src/services/utils/admin-feedback.util.ts
@@ -110,6 +110,25 @@ export class AdminFeedback {
   }
 
   /**
+   * Destructive action message with consistent formatting (red color)
+   */
+  static destructive(title: string, description?: string, fields?: Array<{name: string, value: string, inline?: boolean}>): EmbedBuilder {
+    const embed = new EmbedBuilder()
+      .setColor(0xFF0000) // Red
+      .setTitle(`🗑️ ${title}`);
+    
+    if (description) {
+      embed.setDescription(description);
+    }
+    
+    if (fields) {
+      embed.addFields(fields);
+    }
+    
+    return embed;
+  }
+
+  /**
    * Simple text message for basic responses
    */
   static simple(message: string, isError: boolean = false): string {


### PR DESCRIPTION
This pull request introduces changes to improve handling of duplicate rules in Discord commands and modifies feedback messages for better clarity. Key updates include introducing logic to identify duplicate rules, adding functionality to delete newly created roles when rules are canceled or time out, and updating feedback types for rule-related actions.

### Handling Duplicate Rules:
* [`backend/src/services/discord-commands/handlers/add-rule.handler.ts`](diffhunk://#diff-3adc9d7f7c3b5b32ffa8e40b20f9626670a89f789d3eca761f13e063c8b658c7R547-R582): Added logic to identify duplicate rules by type (`criteria` or `role`) and display appropriate warnings. Newly created roles are deleted if rule creation is canceled or times out. [[1]](diffhunk://#diff-3adc9d7f7c3b5b32ffa8e40b20f9626670a89f789d3eca761f13e063c8b658c7R547-R582) [[2]](diffhunk://#diff-3adc9d7f7c3b5b32ffa8e40b20f9626670a89f789d3eca761f13e063c8b658c7L563-R614) [[3]](diffhunk://#diff-3adc9d7f7c3b5b32ffa8e40b20f9626670a89f789d3eca761f13e063c8b658c7R983-R1012)

### Feedback Message Updates:
* `backend/src/services/discord-commands.service.ts` and `backend/src/services/discord-commands/handlers/remove-rule.handler.ts`: Updated feedback types from `info` or `success` to `destructive` or `warning` for actions like rule creation cancellation, timeout, and removal to better reflect the nature of the actions. [[1]](diffhunk://#diff-de3f524b0d1dd03b44be9c5aa263c0bc94afdb094969dd1aa20d7f0949cbb02fL156-R156) [[2]](diffhunk://#diff-de3f524b0d1dd03b44be9c5aa263c0bc94afdb094969dd1aa20d7f0949cbb02fL648-R642) [[3]](diffhunk://#diff-de3f524b0d1dd03b44be9c5aa263c0bc94afdb094969dd1aa20d7f0949cbb02fL1082-R1076) [[4]](diffhunk://#diff-bc9f8f9d214a84cd3ea97196088289d605b296af800f5bd2d9972011b7d59a79L245-R245)

### Role Management Enhancements:
* [`backend/src/services/discord-commands/handlers/add-rule.handler.ts`](diffhunk://#diff-3adc9d7f7c3b5b32ffa8e40b20f9626670a89f789d3eca761f13e063c8b658c7R547-R582): Enhanced role management by ensuring roles created during rule creation are removed if the process is canceled or times out. Added detailed feedback for administrators regarding duplicate rules and newly created roles. [[1]](diffhunk://#diff-3adc9d7f7c3b5b32ffa8e40b20f9626670a89f789d3eca761f13e063c8b658c7R547-R582) [[2]](diffhunk://#diff-3adc9d7f7c3b5b32ffa8e40b20f9626670a89f789d3eca761f13e063c8b658c7L563-R614)

### Pagination Adjustments:
* [`backend/src/services/data.service.ts`](diffhunk://#diff-787fb42aa2af35437c15724cd04111fe517dfa754c9409987bf43539149171a7L205-R206): Adjusted pagination settings, increasing `pageSize` from 1000 to 2000 and reducing `maxPages` from 10 to 5 for better performance and data handling.