### PR TITLE
feat: Refine dup rule handling and msging for rule creation and restore

### DIFF
--- a/backend/src/services/discord-commands.service.ts
+++ b/backend/src/services/discord-commands.service.ts
@@ -234,7 +234,7 @@ export class DiscordCommandsService {
 
       // Use existing verification message
       const embed = AdminFeedback.success(
-        isDuplicateConfirmed ? 'Duplicate Rule Created' : 'Rule Added',
+        isDuplicateConfirmed ? 'Additional Rule Created' : 'Rule Added',
         `Rule ${newRule.id} for <#${channel.id}> and <@&${role.id}> ${hasExistingMessage ? 'has been added using existing verification message' : 'created'}.`
       );
 
@@ -323,7 +323,7 @@ export class DiscordCommandsService {
       // No need to track message_id in database anymore
 
       const embed = AdminFeedback.success(
-        isDuplicateConfirmed ? 'Duplicate Rule Created' : 'Rule Added',
+        isDuplicateConfirmed ? 'Additional Rule Created' : 'Rule Added',
         `Rule ${newRule.id} for <#${channel.id}> and <@&${role.id}> ${messageCreated ? 'has been added with new verification message' : 'has been added using existing verification message'}.`
       );
 

--- a/backend/src/services/discord-commands/interactions/removal-undo.interaction.ts
+++ b/backend/src/services/discord-commands/interactions/removal-undo.interaction.ts
@@ -296,7 +296,11 @@ export class RemovalUndoInteractionHandler {
     
     // Create rule info fields for the restored rule
     const ruleInfoFields = this.createRuleInfoFields(removedRule);
-    const embedTitle = removedRule.isDuplicateRule ? 'Duplicate Rule Restored' : 'Rule Restored';
+    const embedTitle = removedRule.isDuplicateRule 
+      ? (removedRule.duplicateType === 'role' 
+          ? 'Rule Restored to Existing Role' 
+          : 'Additional Rule Restored')
+      : 'Rule Restored';
     const embed = AdminFeedback.success(
       embedTitle, 
       `Rule ${recreatedRule.id} for <#${removedRule.channel_id}> and <@&${removedRule.role_id}> has been restored.`

--- a/backend/src/services/discord-commands/interactions/restore-undo.interaction.ts
+++ b/backend/src/services/discord-commands/interactions/restore-undo.interaction.ts
@@ -242,7 +242,11 @@ export class RestoreUndoInteractionHandler {
     });
 
     // Create "Rule Removed" message with undo button
-    const embedTitle = restoredRuleData.isDuplicateRule ? 'Duplicate Rule Removed' : 'Rule Removed';
+    const embedTitle = restoredRuleData.isDuplicateRule 
+      ? (restoredRuleData.duplicateType === 'role' 
+          ? 'Rule Removed for Existing Role' 
+          : 'Additional Rule Removed')
+      : 'Rule Removed';
     const embed = AdminFeedback.destructive(
       embedTitle, 
       `Rule ${restoredRuleData.id} for ${restoredRuleData.channel_name} and @${restoredRuleData.role_name} has been removed.`

--- a/backend/src/services/discord-commands/interactions/rule-confirmation.interaction.ts
+++ b/backend/src/services/discord-commands/interactions/rule-confirmation.interaction.ts
@@ -147,7 +147,11 @@ export class RuleConfirmationInteractionHandler {
         attribute_value: ruleToRemove.attribute_value,
         min_items: ruleToRemove.min_items
       });
-      const embedTitle = confirmationInfo.isDuplicateRule ? 'Duplicate Rule Removed' : 'Rule Removed';
+      const embedTitle = confirmationInfo.isDuplicateRule 
+        ? (confirmationInfo.duplicateType === 'role' 
+            ? 'Rule Removed for Existing Role' 
+            : 'Additional Rule Removed')
+        : 'Rule Removed';
       const embed = AdminFeedback.destructive(embedTitle, `Rule ${ruleToRemove.id} for ${ruleToRemove.channel_name} and @${ruleToRemove.role_name} has been removed.`);
       embed.addFields(ruleInfoFields);
       


### PR DESCRIPTION
This pull request refines the terminology used in Discord command handlers to better distinguish between duplicate rules and their associated types (criteria-based or role-based). It also improves the clarity of user-facing messages and embeds by dynamically adjusting titles and descriptions based on the type of rule being processed. Additionally, it simplifies logic for determining duplicate types and enhances code readability.

### Terminology Refinements in User-Facing Messages:
* [`backend/src/services/discord-commands.service.ts`](diffhunk://#diff-de3f524b0d1dd03b44be9c5aa263c0bc94afdb094969dd1aa20d7f0949cbb02fL237-R237): Updated embed titles to replace "Duplicate Rule Created" with more precise terms like "Additional Rule Created" or "Rule Created for Existing Role," depending on the duplicate type. [[1]](diffhunk://#diff-de3f524b0d1dd03b44be9c5aa263c0bc94afdb094969dd1aa20d7f0949cbb02fL237-R237) [[2]](diffhunk://#diff-de3f524b0d1dd03b44be9c5aa263c0bc94afdb094969dd1aa20d7f0949cbb02fL326-R326)

* [`backend/src/services/discord-commands/handlers/add-rule.handler.ts`](diffhunk://#diff-3adc9d7f7c3b5b32ffa8e40b20f9626670a89f789d3eca761f13e063c8b658c7L571-R572): Adjusted cancellation and timeout messages to replace "Duplicate Rule Creation Cancelled" with "Rule Creation Cancelled." [[1]](diffhunk://#diff-3adc9d7f7c3b5b32ffa8e40b20f9626670a89f789d3eca761f13e063c8b658c7L571-R572) [[2]](diffhunk://#diff-3adc9d7f7c3b5b32ffa8e40b20f9626670a89f789d3eca761f13e063c8b658c7L614-R614) [[3]](diffhunk://#diff-3adc9d7f7c3b5b32ffa8e40b20f9626670a89f789d3eca761f13e063c8b658c7L917-R936)

### Dynamic Titles Based on Duplicate Type:
* [`backend/src/services/discord-commands/interactions/removal-undo.interaction.ts`](diffhunk://#diff-962e9fc7b4f6dc057c8ee950907fb64d890a9f93eb2af1ee0872a529d18057afL299-R303): Added logic to dynamically set embed titles for restored rules based on duplicate type (e.g., "Rule Restored to Existing Role" or "Additional Rule Restored").

* [`backend/src/services/discord-commands/interactions/restore-undo.interaction.ts`](diffhunk://#diff-6fb2b022350dc2caaa22d062b022d8cb59d42efea4ce4d7a826c2ce373bcb582L245-R249): Enhanced embed titles for removed rules to reflect duplicate type (e.g., "Rule Removed for Existing Role" or "Additional Rule Removed").

* [`backend/src/services/discord-commands/interactions/rule-confirmation.interaction.ts`](diffhunk://#diff-3412bca7801636e12a7d7d05c376ec8cea5d884d4d2a40dddb037b72fce60cceL150-R154): Updated confirmation messages for removed rules to include duplicate type-specific titles.

### Code Simplification and Logic Enhancements:
* [`backend/src/services/discord-commands/handlers/add-rule.handler.ts`](diffhunk://#diff-3adc9d7f7c3b5b32ffa8e40b20f9626670a89f789d3eca761f13e063c8b658c7R642-R644): Simplified duplicate type determination by declaring `duplicateType` at the function level and removing redundant calls to determine duplicate type. Improved logic to dynamically set embed titles based on duplicate type. [[1]](diffhunk://#diff-3adc9d7f7c3b5b32ffa8e40b20f9626670a89f789d3eca761f13e063c8b658c7R642-R644) [[2]](diffhunk://#diff-3adc9d7f7c3b5b32ffa8e40b20f9626670a89f789d3eca761f13e063c8b658c7R680-R700) [[3]](diffhunk://#diff-3adc9d7f7c3b5b32ffa8e40b20f9626670a89f789d3eca761f13e063c8b658c7R820-R825) [[4]](diffhunk://#diff-3adc9d7f7c3b5b32ffa8e40b20f9626670a89f789d3eca761f13e063c8b658c7L842-R863)