### PR TITLE
fix: Update ephemeral message handling to use MessageFlags.Ephemeral

### DIFF
--- a/backend/src/services/discord-commands.service.ts
+++ b/backend/src/services/discord-commands.service.ts
@@ -645,7 +645,7 @@ export class DiscordCommandsService {
     const messageContent = {
       embeds: [embed],
       components: [undoButton],
-      ...(ephemeral && { ephemeral: true })
+      ...(ephemeral && { flags: MessageFlags.Ephemeral })
     };
 
     if (isReply) {
@@ -721,7 +721,7 @@ export class DiscordCommandsService {
     const messageContent = {
       embeds: [embed],
       components,
-      ...(ephemeral && { ephemeral: true })
+      ...(ephemeral && { flags: MessageFlags.Ephemeral })
     };
 
     if (isReply) {
@@ -809,7 +809,7 @@ export class DiscordCommandsService {
     const messageContent = {
       embeds: [embed],
       components,
-      ephemeral: true
+      flags: MessageFlags.Ephemeral
     };
 
     await interaction.reply(messageContent);
@@ -859,7 +859,7 @@ export class DiscordCommandsService {
     if (!cancelledRule) {
       await interaction.reply({
         content: AdminFeedback.simple('Undo session expired. Rule cancellation cannot be undone.', true),
-        ephemeral: true
+        flags: MessageFlags.Ephemeral
       });
       return;
     }
@@ -906,7 +906,7 @@ export class DiscordCommandsService {
       await interaction.reply({
         embeds: [embed],
         components: [undoButton],
-        ephemeral: true
+        flags: MessageFlags.Ephemeral
       });
       
       // Set up button interaction handler for potential undo of this creation
@@ -918,7 +918,7 @@ export class DiscordCommandsService {
       Logger.error('Error undoing rule cancellation:', error);
       await interaction.reply({
         content: AdminFeedback.simple(`Error creating rule: ${error.message}`, true),
-        ephemeral: true
+        flags: MessageFlags.Ephemeral
       });
     }
   }

--- a/backend/src/services/discord-commands/handlers/add-rule.handler.ts
+++ b/backend/src/services/discord-commands/handlers/add-rule.handler.ts
@@ -9,7 +9,8 @@ import {
   ComponentType,
   ButtonInteraction,
   ChannelType,
-  GuildTextBasedChannel
+  GuildTextBasedChannel,
+  MessageFlags
 } from 'discord.js';
 import { DbService } from '../../db.service';
 import { DiscordMessageService } from '../../discord-message.service';
@@ -51,7 +52,7 @@ export class AddRuleHandler {
    */
   async handle(interaction: ChatInputCommandInteraction): Promise<void> {
     try {
-      await interaction.deferReply({ ephemeral: true });
+      await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
       // Validate input parameters
       const params = await this.validateInputParams(interaction);
@@ -90,7 +91,7 @@ export class AddRuleHandler {
       if (interaction.deferred) {
         await interaction.editReply('An error occurred while adding the rule.');
       } else {
-        await interaction.deferReply({ ephemeral: true });
+        await interaction.deferReply({ flags: MessageFlags.Ephemeral });
         await interaction.editReply({ 
           content: AdminFeedback.simple('An error occurred while adding the rule.', true)
         });

--- a/backend/src/services/discord-commands/handlers/list-rules.handler.ts
+++ b/backend/src/services/discord-commands/handlers/list-rules.handler.ts
@@ -50,7 +50,7 @@ export class ListRulesHandler {
       } else {
         await interaction.reply({
           content: AdminFeedback.simple(errorMessage, true),
-          ephemeral: true
+          flags: MessageFlags.Ephemeral
         });
       }
     }

--- a/backend/src/services/discord-commands/handlers/remove-rule.handler.ts
+++ b/backend/src/services/discord-commands/handlers/remove-rule.handler.ts
@@ -75,7 +75,7 @@ export class RemoveRuleHandler {
           // Some valid rules, show warning but continue
           await interaction.followUp({
             content: AdminFeedback.simple(`⚠️ ${notFoundMessage}`, true),
-            ephemeral: true
+            flags: MessageFlags.Ephemeral
           });
         }
       }

--- a/backend/src/services/discord-commands/interactions/duplicate-rule-confirmation.interaction.ts
+++ b/backend/src/services/discord-commands/interactions/duplicate-rule-confirmation.interaction.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger, Inject, forwardRef } from '@nestjs/common';
-import { ChatInputCommandInteraction, TextChannel, Role, ActionRowBuilder, ButtonBuilder, ButtonStyle, ComponentType } from 'discord.js';
+import { ChatInputCommandInteraction, TextChannel, Role, ActionRowBuilder, ButtonBuilder, ButtonStyle, ComponentType, MessageFlags } from 'discord.js';
 import { AdminFeedback } from '../../utils/admin-feedback.util';
 import { RuleConfirmationInteractionHandler } from './rule-confirmation.interaction';
 
@@ -120,12 +120,12 @@ export class DuplicateRuleConfirmationInteractionHandler {
           if (!i.replied && !i.deferred) {
             await i.reply({
               content: AdminFeedback.simple(`Error: ${error.message}`, true),
-              ephemeral: true
+              flags: MessageFlags.Ephemeral
             });
           } else if (i.replied) {
             await i.followUp({
               content: AdminFeedback.simple(`Error: ${error.message}`, true),
-              ephemeral: true
+              flags: MessageFlags.Ephemeral
             });
           }
         } catch (responseError) {
@@ -202,12 +202,12 @@ export class DuplicateRuleConfirmationInteractionHandler {
           if (!i.replied && !i.deferred) {
             await i.reply({
               content: AdminFeedback.simple(`Error: ${error.message}`, true),
-              ephemeral: true
+              flags: MessageFlags.Ephemeral
             });
           } else if (i.replied) {
             await i.followUp({
               content: AdminFeedback.simple(`Error: ${error.message}`, true),
-              ephemeral: true
+              flags: MessageFlags.Ephemeral
             });
           }
         } catch (responseError) {

--- a/backend/src/services/discord-commands/interactions/removal-undo.interaction.ts
+++ b/backend/src/services/discord-commands/interactions/removal-undo.interaction.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger, Inject, forwardRef } from '@nestjs/common';
-import { ButtonInteraction, ChatInputCommandInteraction, ComponentType, ActionRowBuilder, ButtonBuilder, ButtonStyle } from 'discord.js';
+import { ButtonInteraction, ChatInputCommandInteraction, ComponentType, ActionRowBuilder, ButtonBuilder, ButtonStyle, MessageFlags } from 'discord.js';
 import { DbService } from '../../db.service';
 import { AdminFeedback } from '../../utils/admin-feedback.util';
 import { RestoreUndoInteractionHandler } from './restore-undo.interaction';
@@ -116,7 +116,7 @@ export class RemovalUndoInteractionHandler {
       if (!interaction.replied && !interaction.deferred) {
         await interaction.reply({
           content: AdminFeedback.simple('Undo session expired. Rule removal cannot be undone.', true),
-          ephemeral: true
+          flags: MessageFlags.Ephemeral
         });
       }
       return;
@@ -127,7 +127,7 @@ export class RemovalUndoInteractionHandler {
       // But first check if the interaction is still valid
       if (!interaction.replied && !interaction.deferred) {
         try {
-          await interaction.deferReply({ ephemeral: true });
+          await interaction.deferReply({ flags: MessageFlags.Ephemeral });
         } catch (deferError) {
           // If we can't defer, the interaction is likely expired
           this.logger.warn('Failed to defer interaction, likely expired:', deferError.message);
@@ -165,7 +165,7 @@ export class RemovalUndoInteractionHandler {
         if (!interaction.replied && !interaction.deferred) {
           await interaction.reply({
             content: AdminFeedback.simple(`Error restoring rule(s): ${error.message}`, true),
-            ephemeral: true
+            flags: MessageFlags.Ephemeral
           });
         } else if (interaction.deferred && !interaction.replied) {
           await interaction.editReply({
@@ -175,7 +175,7 @@ export class RemovalUndoInteractionHandler {
           // Use followUp if already replied
           await interaction.followUp({
             content: AdminFeedback.simple(`Error restoring rule(s): ${error.message}`, true),
-            ephemeral: true
+            flags: MessageFlags.Ephemeral
           });
         }
       } catch (responseError) {

--- a/backend/src/services/discord-commands/interactions/restore-undo.interaction.ts
+++ b/backend/src/services/discord-commands/interactions/restore-undo.interaction.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger, Inject, forwardRef } from '@nestjs/common';
-import { ButtonInteraction, ChatInputCommandInteraction, ComponentType, ActionRowBuilder, ButtonBuilder, ButtonStyle } from 'discord.js';
+import { ButtonInteraction, ChatInputCommandInteraction, ComponentType, ActionRowBuilder, ButtonBuilder, ButtonStyle, MessageFlags } from 'discord.js';
 import { DbService } from '../../db.service';
 import { AdminFeedback } from '../../utils/admin-feedback.util';
 import { RemovalUndoInteractionHandler } from './removal-undo.interaction';
@@ -94,7 +94,7 @@ export class RestoreUndoInteractionHandler {
       if (!interaction.replied && !interaction.deferred) {
         await interaction.reply({
           content: AdminFeedback.simple('Undo session expired. Rule restoration cannot be undone.', true),
-          ephemeral: true
+          flags: MessageFlags.Ephemeral
         });
       }
       return;
@@ -105,7 +105,7 @@ export class RestoreUndoInteractionHandler {
       // But first check if the interaction is still valid
       if (!interaction.replied && !interaction.deferred) {
         try {
-          await interaction.deferReply({ ephemeral: true });
+          await interaction.deferReply({ flags: MessageFlags.Ephemeral });
         } catch (deferError) {
           // If we can't defer, the interaction is likely expired
           this.logger.warn('Failed to defer interaction, likely expired:', deferError.message);
@@ -141,7 +141,7 @@ export class RestoreUndoInteractionHandler {
         if (!interaction.replied && !interaction.deferred) {
           await interaction.reply({
             content: AdminFeedback.simple(`Error removing rule(s): ${error.message}`, true),
-            ephemeral: true
+            flags: MessageFlags.Ephemeral
           });
         } else if (interaction.deferred && !interaction.replied) {
           await interaction.editReply({
@@ -151,7 +151,7 @@ export class RestoreUndoInteractionHandler {
           // Use followUp if already replied
           await interaction.followUp({
             content: AdminFeedback.simple(`Error removing rule(s): ${error.message}`, true),
-            ephemeral: true
+            flags: MessageFlags.Ephemeral
           });
         }
       } catch (responseError) {

--- a/backend/src/services/discord-commands/interactions/rule-confirmation.interaction.ts
+++ b/backend/src/services/discord-commands/interactions/rule-confirmation.interaction.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger, Inject, forwardRef } from '@nestjs/common';
-import { ButtonInteraction, ChatInputCommandInteraction, ComponentType, ActionRowBuilder, ButtonBuilder, ButtonStyle } from 'discord.js';
+import { ButtonInteraction, ChatInputCommandInteraction, ComponentType, ActionRowBuilder, ButtonBuilder, ButtonStyle, MessageFlags } from 'discord.js';
 import { DbService } from '../../db.service';
 import { AdminFeedback } from '../../utils/admin-feedback.util';
 import { RemovalUndoInteractionHandler } from './removal-undo.interaction';
@@ -106,7 +106,7 @@ export class RuleConfirmationInteractionHandler {
     if (!confirmationInfo) {
       await interaction.reply({
         content: AdminFeedback.simple('Undo session expired. Use `/setup remove-rule` if needed.', true),
-        ephemeral: true
+        flags: MessageFlags.Ephemeral
       });
       return;
     }
@@ -179,7 +179,7 @@ export class RuleConfirmationInteractionHandler {
                 .setEmoji('↩️')
             )
         ],
-        ephemeral: true
+        flags: MessageFlags.Ephemeral
       });
 
       // Set up removal undo handler for the "Rule Removed" message
@@ -200,13 +200,13 @@ export class RuleConfirmationInteractionHandler {
         if (!interaction.replied && !interaction.deferred) {
           await interaction.reply({
             content: AdminFeedback.simple(`Error undoing rule: ${error.message}`, true),
-            ephemeral: true
+            flags: MessageFlags.Ephemeral
           });
         } else if (interaction.replied) {
           // Use followUp if already replied
           await interaction.followUp({
             content: AdminFeedback.simple(`Error undoing rule: ${error.message}`, true),
-            ephemeral: true
+            flags: MessageFlags.Ephemeral
           });
         }
       } catch (responseError) {

--- a/backend/src/services/discord.service.ts
+++ b/backend/src/services/discord.service.ts
@@ -263,7 +263,7 @@ export class DiscordService implements OnModuleInit {
    */
   async handleSetupHelp(interaction: ChatInputCommandInteraction): Promise<void> {
     try {
-      await interaction.deferReply({ ephemeral: true });
+      await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
       const embed = new EmbedBuilder()
         .setColor(SETUP_HELP_CONTENT.color)


### PR DESCRIPTION
This pull request updates the handling of ephemeral messages across multiple classes and files in the Discord service by replacing the use of the `ephemeral` property with `flags: MessageFlags.Ephemeral`. This change ensures better alignment with Discord.js's API and improves code consistency.

### Updates to Ephemeral Message Handling:

#### Service-Level Changes:
* [`backend/src/services/discord-commands.service.ts`](diffhunk://#diff-de3f524b0d1dd03b44be9c5aa263c0bc94afdb094969dd1aa20d7f0949cbb02fL648-R648): Replaced `ephemeral: true` with `flags: MessageFlags.Ephemeral` in all occurrences where ephemeral messages are constructed or replied to. [[1]](diffhunk://#diff-de3f524b0d1dd03b44be9c5aa263c0bc94afdb094969dd1aa20d7f0949cbb02fL648-R648) [[2]](diffhunk://#diff-de3f524b0d1dd03b44be9c5aa263c0bc94afdb094969dd1aa20d7f0949cbb02fL724-R724) [[3]](diffhunk://#diff-de3f524b0d1dd03b44be9c5aa263c0bc94afdb094969dd1aa20d7f0949cbb02fL812-R812) [[4]](diffhunk://#diff-de3f524b0d1dd03b44be9c5aa263c0bc94afdb094969dd1aa20d7f0949cbb02fL862-R862) [[5]](diffhunk://#diff-de3f524b0d1dd03b44be9c5aa263c0bc94afdb094969dd1aa20d7f0949cbb02fL909-R909) [[6]](diffhunk://#diff-de3f524b0d1dd03b44be9c5aa263c0bc94afdb094969dd1aa20d7f0949cbb02fL921-R921)

#### Handler-Level Changes:
* [`backend/src/services/discord-commands/handlers/add-rule.handler.ts`](diffhunk://#diff-3adc9d7f7c3b5b32ffa8e40b20f9626670a89f789d3eca761f13e063c8b658c7L54-R55): Updated the `deferReply` method to use `flags: MessageFlags.Ephemeral` instead of `ephemeral: true`. [[1]](diffhunk://#diff-3adc9d7f7c3b5b32ffa8e40b20f9626670a89f789d3eca761f13e063c8b658c7L54-R55) [[2]](diffhunk://#diff-3adc9d7f7c3b5b32ffa8e40b20f9626670a89f789d3eca761f13e063c8b658c7L93-R94)
* [`backend/src/services/discord-commands/handlers/list-rules.handler.ts`](diffhunk://#diff-05701f42866f5c1c4f25931937aa66153795d2977089835e9adfb549b47425e7L53-R53): Modified the `reply` method to use `flags: MessageFlags.Ephemeral`.
* [`backend/src/services/discord-commands/handlers/remove-rule.handler.ts`](diffhunk://#diff-bc9f8f9d214a84cd3ea97196088289d605b296af800f5bd2d9972011b7d59a79L78-R78): Adjusted the `followUp` method to use `flags: MessageFlags.Ephemeral`.

#### Interaction-Level Changes:
* Updated imports to include `MessageFlags` in multiple interaction files:
  - `duplicate-rule-confirmation.interaction.ts`
  - `removal-undo.interaction.ts`
  - `restore-undo.interaction.ts`
  - `rule-confirmation.interaction.ts`
* Replaced instances of `ephemeral: true` with `flags: MessageFlags.Ephemeral` in interaction handlers:
  - `duplicate-rule-confirmation.interaction.ts` [[1]](diffhunk://#diff-2ebb6735c0fb6b18bd2508f273b078b7fd63ba55d2e0eaa26788b8add42b6ca4L123-R128) [[2]](diffhunk://#diff-2ebb6735c0fb6b18bd2508f273b078b7fd63ba55d2e0eaa26788b8add42b6ca4L205-R210)
  - `removal-undo.interaction.ts` [[1]](diffhunk://#diff-962e9fc7b4f6dc057c8ee950907fb64d890a9f93eb2af1ee0872a529d18057afL119-R119) [[2]](diffhunk://#diff-962e9fc7b4f6dc057c8ee950907fb64d890a9f93eb2af1ee0872a529d18057afL130-R130) [[3]](diffhunk://#diff-962e9fc7b4f6dc057c8ee950907fb64d890a9f93eb2af1ee0872a529d18057afL168-R168) [[4]](diffhunk://#diff-962e9fc7b4f6dc057c8ee950907fb64d890a9f93eb2af1ee0872a529d18057afL178-R178)
  - `restore-undo.interaction.ts` [[1]](diffhunk://#diff-6fb2b022350dc2caaa22d062b022d8cb59d42efea4ce4d7a826c2ce373bcb582L97-R97) [[2]](diffhunk://#diff-6fb2b022350dc2caaa22d062b022d8cb59d42efea4ce4d7a826c2ce373bcb582L108-R108) [[3]](diffhunk://#diff-6fb2b022350dc2caaa22d062b022d8cb59d42efea4ce4d7a826c2ce373bcb582L144-R144) [[4]](diffhunk://#diff-6fb2b022350dc2caaa22d062b022d8cb59d42efea4ce4d7a826c2ce373bcb582L154-R154)
  - `rule-confirmation.interaction.ts` [[1]](diffhunk://#diff-3412bca7801636e12a7d7d05c376ec8cea5d884d4d2a40dddb037b72fce60cceL109-R109) [[2]](diffhunk://#diff-3412bca7801636e12a7d7d05c376ec8cea5d884d4d2a40dddb037b72fce60cceL182-R182) [[3]](diffhunk://#diff-3412bca7801636e12a7d7d05c376ec8cea5d884d4d2a40dddb037b72fce60cceL203-R209)

#### General Service Changes:
* [`backend/src/services/discord.service.ts`](diffhunk://#diff-f4f7eaa546e192917a87a7fe97c6c24e6abd71d7f1a248374cb8050c0952eb71L266-R266): Updated the `deferReply` method in `handleSetupHelp` to use `flags: MessageFlags.Ephemeral`.