### PR TITLE
feat: clean attribute values and update Discord service integration

### DIFF
--- a/backend/src/services/data.service.ts
+++ b/backend/src/services/data.service.ts
@@ -294,6 +294,39 @@ export class DataService {
   }
 
   /**
+   * Get attribute values for autocomplete without occurrence counts
+   * This method returns clean values for Discord autocomplete to avoid display issues
+   * 
+   * @param attributeKey - The attribute key to search for
+   * @param slug - Collection slug to filter by (optional)
+   * @returns Array of clean attribute values sorted by rarity (rarest first)
+   */
+  async getAttributeValuesForAutocomplete(attributeKey: string, slug?: string): Promise<string[]> {
+    try {
+      if (!attributeKey || attributeKey === 'ALL') {
+        return [];
+      }
+
+      // Get the full values with counts
+      const valuesWithCounts = await this.getAttributeValues(attributeKey, slug);
+      
+      // Extract clean values without occurrence counts
+      const cleanValues = valuesWithCounts.map(value => {
+        const match = value.match(/^(.+?)\s*\((\d+)×\)$/);
+        if (match) {
+          return match[1].trim(); // Return just the clean value
+        }
+        return value; // Fallback for values without count format
+      });
+
+      return cleanValues;
+    } catch (error) {
+      this.logger.error('Error getting attribute values for autocomplete:', error);
+      return [];
+    }
+  }
+
+  /**
    * Check asset ownership with specific criteria (slug, attributes, minimum count)
    * 
    * @param address - Wallet address to check


### PR DESCRIPTION
This pull request introduces a new method in the `DataService` to streamline the retrieval of clean attribute values for Discord autocomplete functionality. Additionally, the `DiscordService` has been updated to leverage this new method, simplifying the logic and improving maintainability.

### Enhancements to Data Retrieval:

* [`backend/src/services/data.service.ts`](diffhunk://#diff-787fb42aa2af35437c15724cd04111fe517dfa754c9409987bf43539149171a7R296-R328): Added `getAttributeValuesForAutocomplete` method to retrieve clean attribute values without occurrence counts, sorted by rarity. This improves the data's compatibility with Discord autocomplete.

### Updates to Discord Autocomplete Logic:

* [`backend/src/services/discord.service.ts`](diffhunk://#diff-f4f7eaa546e192917a87a7fe97c6c24e6abd71d7f1a248374cb8050c0952eb71R764-R766): Updated `DiscordService` to use the new `getAttributeValuesForAutocomplete` method instead of `getAttributeValues`, simplifying the filtering logic by directly handling clean values. [[1]](diffhunk://#diff-f4f7eaa546e192917a87a7fe97c6c24e6abd71d7f1a248374cb8050c0952eb71R764-R766) [[2]](diffhunk://#diff-f4f7eaa546e192917a87a7fe97c6c24e6abd71d7f1a248374cb8050c0952eb71L791-R797)
* [`backend/src/services/discord.service.ts`](diffhunk://#diff-f4f7eaa546e192917a87a7fe97c6c24e6abd71d7f1a248374cb8050c0952eb71L807-L822): Removed redundant logic for extracting and formatting values with occurrence counts, as the new method already provides clean values.
* [`backend/src/services/discord.service.ts`](diffhunk://#diff-f4f7eaa546e192917a87a7fe97c6c24e6abd71d7f1a248374cb8050c0952eb71R823): Added debug logging to display the first three autocomplete choices for better traceability during development.