### PR TITLE
feat: Enhance bot security w/ admin-only cmd perms and refresh script

### DIFF
--- a/backend/scripts/refresh-admin-commands.sh
+++ b/backend/scripts/refresh-admin-commands.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Script to refresh Discord slash commands with new permissions
+# This forces Discord to re-register the commands with the Administrator permission requirement
+
+echo "🔄 Refreshing Discord slash commands with admin-only permissions..."
+
+cd /home/snep/devibe/verethfier-fresh/backend
+
+# Build the project first
+echo "📦 Building project..."
+npm run build
+
+# Start the bot briefly to register commands (it will auto-register on startup)
+echo "🤖 Starting bot to register commands..."
+timeout 30s npm run start:dev || true
+
+echo "✅ Discord slash commands should now be restricted to Administrators only!"
+echo ""
+echo "🔒 Security Status:"
+echo "   • All /setup commands now require Administrator permissions"
+echo "   • Non-admin users will see 'Access Denied' if they somehow get access"
+echo "   • Discord will hide the commands from non-admin users automatically"
+echo ""
+echo "💡 Note: It may take a few minutes for Discord to update command permissions across all servers."

--- a/backend/src/config/environment.config.ts
+++ b/backend/src/config/environment.config.ts
@@ -36,6 +36,7 @@ export class EnvironmentConfig {
       'EVERY_DAY_AT_MIDNIGHT': '0 0 * * *',
       'EVERY_4_HOURS': '0 */4 * * *',
       'EVERY_HOUR': '0 * * * *',
+      'EVERY_1_HOUR': '0 * * * *', // Same as EVERY_HOUR for consistency
     };
     
     return cronMap[cronValue] || cronValue; // Use mapping if exists, otherwise use as-is

--- a/backend/src/services/discord.service.ts
+++ b/backend/src/services/discord.service.ts
@@ -221,6 +221,16 @@ export class DiscordService implements OnModuleInit {
    */
   async handleSetup(interaction: ChatInputCommandInteraction): Promise<void> {
     try {
+      // 🔒 SECURITY: Check for Administrator permissions
+      if (!interaction.memberPermissions?.has(PermissionFlagsBits.Administrator)) {
+        await interaction.reply({
+          content: '🚫 **Access Denied**\n\nThis command requires **Administrator** permissions to use.',
+          flags: MessageFlags.Ephemeral
+        });
+        Logger.warn(`Unauthorized setup command attempt by user ${interaction.user.id} (${interaction.user.tag}) in guild ${interaction.guildId}`);
+        return;
+      }
+
       const sub = interaction.options.getSubcommand();
       
       if (sub === 'add-rule') {
@@ -409,6 +419,7 @@ export class DiscordService implements OnModuleInit {
       new SlashCommandBuilder()
         .setName('setup')
         .setDescription('Setup the bot for the first time or manage rules')
+        .setDefaultMemberPermissions(PermissionFlagsBits.Administrator) // 🔒 ADMIN ONLY
         .addSubcommand(sc =>
           sc.setName('add-rule')
             .setDescription('Add a new verification rule')


### PR DESCRIPTION
This pull request introduces changes to enhance the security of Discord bot commands, improve consistency in cron job mappings, and add a script for refreshing admin-only permissions for Discord slash commands.

### Security Enhancements for Discord Bot Commands:
* [`backend/src/services/discord.service.ts`](diffhunk://#diff-f4f7eaa546e192917a87a7fe97c6c24e6abd71d7f1a248374cb8050c0952eb71R224-R233): Added a check to ensure that the `/setup` command can only be executed by users with Administrator permissions. Unauthorized attempts are logged with user and guild details.
* [`backend/src/services/discord.service.ts`](diffhunk://#diff-f4f7eaa546e192917a87a7fe97c6c24e6abd71d7f1a248374cb8050c0952eb71R422): Updated the `setup` slash command to require Administrator permissions by default using `setDefaultMemberPermissions`.

### Cron Job Mapping Consistency:
* [`backend/src/config/environment.config.ts`](diffhunk://#diff-e990b28120ab58af2cb408f6b450f2af106be4879ceab6b6ccdc96924bb79fadR39): Added a new mapping for `EVERY_1_HOUR`, which is identical to `EVERY_HOUR`, to improve naming consistency.

### Admin Command Refresh Script:
* [`backend/scripts/refresh-admin-commands.sh`](diffhunk://#diff-2a7c7dc864a331de4e1975d8af484ef00727832b9c3472d9b72ed09200708c4aR1-R25): Introduced a new script to refresh Discord slash commands, ensuring they are re-registered with Administrator-only permissions. This includes building the project and briefly starting the bot for command registration.